### PR TITLE
Improve traverseArray from quadratic to linear

### DIFF
--- a/src/Data/Traversable.js
+++ b/src/Data/Traversable.js
@@ -8,10 +8,21 @@ exports.traverseArrayImpl = function () {
     this.fn = fn;
   }
 
-  function consArray(x) {
+  var emptyList = {};
+
+  function consList (x) {
     return function (xs) {
-      return [x].concat(xs);
+      return { head: x, tail: xs };
     };
+  }
+
+  function listToArray (list) {
+    var arr = [];
+    while (list !== emptyList) {
+      arr.push(list.head);
+      list = list.tail;
+    }
+    return arr;
   }
 
   return function (apply) {
@@ -20,7 +31,7 @@ exports.traverseArrayImpl = function () {
         return function (f) {
           /* jshint maxparams: 2 */
           var buildFrom = function (x, ys) {
-            return apply(map(consArray)(f(x)))(ys);
+            return apply(map(consList)(f(x)))(ys);
           };
 
           /* jshint maxparams: 3 */
@@ -36,12 +47,12 @@ exports.traverseArrayImpl = function () {
           };
 
           return function (array) {
-            var result = go(pure([]), array.length, array);
+            var result = go(pure(emptyList), array.length, array);
             while (result instanceof Cont) {
               result = result.fn();
             }
 
-            return result;
+            return map(listToArray)(result);
           };
         };
       };


### PR DESCRIPTION
This uses a list as an intermediate representation while building up the result, which has the benefit of O(1) cons, rather than O(n). Then, we just need to convert this list to an array in the final step, which is
also O(n). So the complexity of traverse is reduced from O(n^2) to O(n).