### PR TITLE
Further performance boost for traverseArray

### DIFF
--- a/src/Data/Traversable.js
+++ b/src/Data/Traversable.js
@@ -3,6 +3,8 @@
 
 // module Data.Traversable
 
+// jshint maxparams: 3
+
 exports.traverseArrayImpl = function () {
   function Cont (fn) {
     this.fn = fn;
@@ -10,9 +12,14 @@ exports.traverseArrayImpl = function () {
 
   var emptyList = {};
 
+  var ConsCell = function (head, tail) {
+    this.head = head;
+    this.tail = tail;
+  };
+
   function consList (x) {
     return function (xs) {
-      return { head: x, tail: xs };
+      return new ConsCell(x, xs);
     };
   }
 
@@ -29,12 +36,10 @@ exports.traverseArrayImpl = function () {
     return function (map) {
       return function (pure) {
         return function (f) {
-          /* jshint maxparams: 2 */
           var buildFrom = function (x, ys) {
             return apply(map(consList)(f(x)))(ys);
           };
 
-          /* jshint maxparams: 3 */
           var go = function (acc, currentLen, xs) {
             if (currentLen === 0) {
               return acc;


### PR DESCRIPTION
Using a 'class' as @garyb suggested has given a performance boost of around 2.4x on Node.js.