### PR TITLE
Default impls for Foldable & Traversable methods

### DIFF
--- a/docs/Data/Bifoldable.md
+++ b/docs/Data/Bifoldable.md
@@ -16,6 +16,60 @@ A fold for such a structure requires two step functions, one for each type
 argument. Type class instances should choose the appropriate step function based
 on the type of the element encountered at each point of the fold.
 
+Default implementations are provided by the following functions:
+
+- `bifoldrDefault`
+- `bifoldlDefault`
+- `bifoldMapDefaultR`
+- `bifoldMapDefaultL`
+
+Note: some combinations of the default implementations are unsafe to
+use together - causing a non-terminating mutually recursive cycle.
+These combinations are documented per function.
+
+#### `bifoldrDefault`
+
+``` purescript
+bifoldrDefault :: forall p a b c. (Bifoldable p) => (a -> c -> c) -> (b -> c -> c) -> c -> p a b -> c
+```
+
+A default implementation of `bifoldr` using `bifoldMap`.
+
+Note: when defining a `Bifoldable` instance, this function is unsafe to
+use in combination with `bifoldMapDefaultR`.
+
+#### `bifoldlDefault`
+
+``` purescript
+bifoldlDefault :: forall p a b c. (Bifoldable p) => (c -> a -> c) -> (c -> b -> c) -> c -> p a b -> c
+```
+
+A default implementation of `bifoldl` using `bifoldMap`.
+
+Note: when defining a `Bifoldable` instance, this function is unsafe to
+use in combination with `bifoldMapDefaultL`.
+
+#### `bifoldMapDefaultR`
+
+``` purescript
+bifoldMapDefaultR :: forall p m a b. (Bifoldable p, Monoid m) => (a -> m) -> (b -> m) -> p a b -> m
+```
+
+A default implementation of `bifoldMap` using `bifoldr`.
+
+Note: when defining a `Bifoldable` instance, this function is unsafe to
+use in combination with `bifoldrDefault`.
+
+#### `bifoldMapDefaultL`
+
+``` purescript
+bifoldMapDefaultL :: forall p m a b. (Bifoldable p, Monoid m) => (a -> m) -> (b -> m) -> p a b -> m
+```
+
+A default implementation of `bifoldMap` using `bifoldl`.
+
+Note: when defining a `Bifoldable` instance, this function is unsafe to
+use in combination with `bifoldlDefault`.
 
 #### `bifold`
 

--- a/docs/Data/Bitraversable.md
+++ b/docs/Data/Bitraversable.md
@@ -15,6 +15,26 @@ A traversal for such a structure requires two functions, one for each type
 argument. Type class instances should choose the appropriate function based
 on the type of the element encountered at each point of the traversal.
 
+Default implementations are provided by the following functions:
+
+- `bitraverseDefault`
+- `bisequenceDefault`
+
+#### `bitraverseDefault`
+
+``` purescript
+bitraverseDefault :: forall t f a b c d. (Bitraversable t, Applicative f) => (a -> f c) -> (b -> f d) -> t a b -> f (t c d)
+```
+
+A default implementation of `bitraverse` using `bisequence` and `bimap`.
+
+#### `bisequenceDefault`
+
+``` purescript
+bisequenceDefault :: forall t f a b. (Bitraversable t, Applicative f) => t (f a) (f b) -> f (t a b)
+```
+
+A default implementation of `bisequence` using `bitraverse`.
 
 #### `bifor`
 

--- a/docs/Data/Foldable.md
+++ b/docs/Data/Foldable.md
@@ -19,10 +19,10 @@ Default implementations are provided by the following functions:
 
 - `foldrDefault`
 - `foldlDefault`
-- `foldMapDefaultL`
 - `foldMapDefaultR`
+- `foldMapDefaultL`
 
-Note: that some combinations of the default implementations are unsafe to
+Note: some combinations of the default implementations are unsafe to
 use together - causing a non-terminating mutually recursive cycle.
 These combinations are documented per function.
 
@@ -45,7 +45,7 @@ instance foldableMultiplicative :: Foldable Multiplicative
 foldrDefault :: forall f a b. (Foldable f) => (a -> b -> b) -> b -> f a -> b
 ```
 
-A default implementation of `foldr` using `foldMap`
+A default implementation of `foldr` using `foldMap`.
 
 Note: when defining a `Foldable` instance, this function is unsafe to use
 in combination with `foldMapDefaultR`.
@@ -56,21 +56,10 @@ in combination with `foldMapDefaultR`.
 foldlDefault :: forall f a b. (Foldable f) => (b -> a -> b) -> b -> f a -> b
 ```
 
-A default implementation of `foldl` using `foldMap`
+A default implementation of `foldl` using `foldMap`.
 
 Note: when defining a `Foldable` instance, this function is unsafe to use
 in combination with `foldMapDefaultL`.
-
-#### `foldMapDefaultL`
-
-``` purescript
-foldMapDefaultL :: forall f a m. (Foldable f, Monoid m) => (a -> m) -> f a -> m
-```
-
-A default implementation of `foldMap` using `foldl`
-
-Note: when defining a `Foldable` instance, this function is unsafe to use
-in combination with `foldlDefault`.
 
 #### `foldMapDefaultR`
 
@@ -78,10 +67,21 @@ in combination with `foldlDefault`.
 foldMapDefaultR :: forall f a m. (Foldable f, Monoid m) => (a -> m) -> f a -> m
 ```
 
-A default implementation of `foldMap` using `foldr`
+A default implementation of `foldMap` using `foldr`.
 
 Note: when defining a `Foldable` instance, this function is unsafe to use
 in combination with `foldrDefault`.
+
+#### `foldMapDefaultL`
+
+``` purescript
+foldMapDefaultL :: forall f a m. (Foldable f, Monoid m) => (a -> m) -> f a -> m
+```
+
+A default implementation of `foldMap` using `foldl`.
+
+Note: when defining a `Foldable` instance, this function is unsafe to use
+in combination with `foldlDefault`.
 
 #### `fold`
 

--- a/docs/Data/Foldable.md
+++ b/docs/Data/Foldable.md
@@ -28,6 +28,38 @@ instance foldableConj :: Foldable Conj
 instance foldableMultiplicative :: Foldable Multiplicative
 ```
 
+#### `foldrDefault`
+
+``` purescript
+foldrDefault :: forall f a b. (Foldable f) => (a -> b -> b) -> b -> f a -> b
+```
+
+A default implementation of `foldr` using `foldMap`
+
+#### `foldlDefault`
+
+``` purescript
+foldlDefault :: forall f a b. (Foldable f) => (b -> a -> b) -> b -> f a -> b
+```
+
+A default implementation of `foldl` using `foldMap`
+
+#### `foldMapDefaultL`
+
+``` purescript
+foldMapDefaultL :: forall f a m. (Foldable f, Monoid m) => (a -> m) -> f a -> m
+```
+
+A default implementation of `foldMap` using `foldl`
+
+#### `foldMapDefaultR`
+
+``` purescript
+foldMapDefaultR :: forall f a m. (Foldable f, Monoid m) => (a -> m) -> f a -> m
+```
+
+A default implementation of `foldMap` using `foldr`
+
 #### `fold`
 
 ``` purescript

--- a/docs/Data/Foldable.md
+++ b/docs/Data/Foldable.md
@@ -15,6 +15,17 @@ class Foldable f where
 - `foldl` folds a structure from the left
 - `foldMap` folds a structure by accumulating values in a `Monoid`
 
+Default implementations are provided by the following functions:
+
+- `foldrDefault`
+- `foldlDefault`
+- `foldMapDefaultL`
+- `foldMapDefaultR`
+
+Note: that some combinations of the default implementations are unsafe to
+use together - causing a non-terminating mutually recursive cycle.
+These combinations are documented per function.
+
 ##### Instances
 ``` purescript
 instance foldableArray :: Foldable Array
@@ -36,6 +47,9 @@ foldrDefault :: forall f a b. (Foldable f) => (a -> b -> b) -> b -> f a -> b
 
 A default implementation of `foldr` using `foldMap`
 
+Note: when defining a `Foldable` instance, this function is unsafe to use
+in combination with `foldMapDefaultR`.
+
 #### `foldlDefault`
 
 ``` purescript
@@ -43,6 +57,9 @@ foldlDefault :: forall f a b. (Foldable f) => (b -> a -> b) -> b -> f a -> b
 ```
 
 A default implementation of `foldl` using `foldMap`
+
+Note: when defining a `Foldable` instance, this function is unsafe to use
+in combination with `foldMapDefaultL`.
 
 #### `foldMapDefaultL`
 
@@ -52,6 +69,9 @@ foldMapDefaultL :: forall f a m. (Foldable f, Monoid m) => (a -> m) -> f a -> m
 
 A default implementation of `foldMap` using `foldl`
 
+Note: when defining a `Foldable` instance, this function is unsafe to use
+in combination with `foldlDefault`.
+
 #### `foldMapDefaultR`
 
 ``` purescript
@@ -59,6 +79,9 @@ foldMapDefaultR :: forall f a m. (Foldable f, Monoid m) => (a -> m) -> f a -> m
 ```
 
 A default implementation of `foldMap` using `foldr`
+
+Note: when defining a `Foldable` instance, this function is unsafe to use
+in combination with `foldrDefault`.
 
 #### `fold`
 

--- a/docs/Data/Traversable.md
+++ b/docs/Data/Traversable.md
@@ -40,6 +40,22 @@ instance traversableDisj :: Traversable Disj
 instance traversableMultiplicative :: Traversable Multiplicative
 ```
 
+#### `traverseDefault`
+
+``` purescript
+traverseDefault :: forall t a b m. (Traversable t, Applicative m) => (a -> m b) -> t a -> m (t b)
+```
+
+A default implementation of `traverse` using `sequence` and `map`
+
+#### `sequenceDefault`
+
+``` purescript
+sequenceDefault :: forall t a m. (Traversable t, Applicative m) => t (m a) -> m (t a)
+```
+
+A default implementation of `sequence` using `traverse`
+
 #### `for`
 
 ``` purescript

--- a/docs/Data/Traversable.md
+++ b/docs/Data/Traversable.md
@@ -51,7 +51,7 @@ instance traversableMultiplicative :: Traversable Multiplicative
 traverseDefault :: forall t a b m. (Traversable t, Applicative m) => (a -> m b) -> t a -> m (t b)
 ```
 
-A default implementation of `traverse` using `sequence` and `map`
+A default implementation of `traverse` using `sequence` and `map`.
 
 #### `sequenceDefault`
 
@@ -59,7 +59,7 @@ A default implementation of `traverse` using `sequence` and `map`
 sequenceDefault :: forall t a m. (Traversable t, Applicative m) => t (m a) -> m (t a)
 ```
 
-A default implementation of `sequence` using `traverse`
+A default implementation of `sequence` using `traverse`.
 
 #### `for`
 

--- a/docs/Data/Traversable.md
+++ b/docs/Data/Traversable.md
@@ -27,6 +27,11 @@ following sense:
 
 - `foldMap f = runConst <<< traverse (Const <<< f)`
 
+Default implementations are provided by the following functions:
+
+- `traverseDefault`
+- `sequenceDefault`
+
 ##### Instances
 ``` purescript
 instance traversableArray :: Traversable Array

--- a/src/Data/Bitraversable.purs
+++ b/src/Data/Bitraversable.purs
@@ -3,7 +3,7 @@ module Data.Bitraversable where
 import Prelude
 
 import Data.Bifoldable
-import Data.Bifunctor (Bifunctor)
+import Data.Bifunctor (Bifunctor, bimap)
 
 -- | `Bitraversable` represents data structures with two type arguments which can be
 -- | traversed.
@@ -12,9 +12,25 @@ import Data.Bifunctor (Bifunctor)
 -- | argument. Type class instances should choose the appropriate function based
 -- | on the type of the element encountered at each point of the traversal.
 -- |
+-- | Default implementations are provided by the following functions:
+-- |
+-- | - `bitraverseDefault`
+-- | - `bisequenceDefault`
 class (Bifunctor t, Bifoldable t) <= Bitraversable t where
   bitraverse :: forall f a b c d. (Applicative f) => (a -> f c) -> (b -> f d) -> t a b -> f (t c d)
   bisequence :: forall f a b. (Applicative f) => t (f a) (f b) -> f (t a b)
+
+
+-- | A default implementation of `bitraverse` using `bisequence` and `bimap`.
+bitraverseDefault :: forall t f a b c d. (Bitraversable t, Applicative f) =>
+                     (a -> f c) -> (b -> f d) -> t a b -> f (t c d)
+bitraverseDefault f g t = bisequence (bimap f g t)
+
+-- | A default implementation of `bisequence` using `bitraverse`.
+bisequenceDefault :: forall t f a b. (Bitraversable t, Applicative f) =>
+                     t (f a) (f b) -> f (t a b)
+bisequenceDefault t = bitraverse id id t
+
 
 -- | Traverse a data structure, accumulating effects and results using an `Applicative` functor.
 bifor :: forall t f a b c d. (Bitraversable t, Applicative f) => t a b -> (a -> f c) -> (b -> f d) -> f (t c d)

--- a/src/Data/Foldable.purs
+++ b/src/Data/Foldable.purs
@@ -42,10 +42,10 @@ import Data.Monoid.Multiplicative (Multiplicative(..))
 -- |
 -- | - `foldrDefault`
 -- | - `foldlDefault`
--- | - `foldMapDefaultL`
 -- | - `foldMapDefaultR`
+-- | - `foldMapDefaultL`
 -- |
--- | Note: that some combinations of the default implementations are unsafe to
+-- | Note: some combinations of the default implementations are unsafe to
 -- | use together - causing a non-terminating mutually recursive cycle.
 -- | These combinations are documented per function.
 class Foldable f where
@@ -54,7 +54,7 @@ class Foldable f where
   foldMap :: forall a m. (Monoid m) => (a -> m) -> f a -> m
 
 
--- | A default implementation of `foldr` using `foldMap`
+-- | A default implementation of `foldr` using `foldMap`.
 -- |
 -- | Note: when defining a `Foldable` instance, this function is unsafe to use
 -- | in combination with `foldMapDefaultR`.
@@ -62,7 +62,7 @@ foldrDefault :: forall f a b. (Foldable f) =>
                 (a -> b -> b) -> b -> f a -> b
 foldrDefault c u xs = runEndo (foldMap (Endo <<< c) xs) u
 
--- | A default implementation of `foldl` using `foldMap`
+-- | A default implementation of `foldl` using `foldMap`.
 -- |
 -- | Note: when defining a `Foldable` instance, this function is unsafe to use
 -- | in combination with `foldMapDefaultL`.
@@ -70,21 +70,21 @@ foldlDefault :: forall f a b. (Foldable f) =>
                 (b -> a -> b) -> b -> f a -> b
 foldlDefault c u xs = runEndo (runDual (foldMap (Dual <<< Endo <<< flip c) xs)) u
 
--- | A default implementation of `foldMap` using `foldl`
--- |
--- | Note: when defining a `Foldable` instance, this function is unsafe to use
--- | in combination with `foldlDefault`.
-foldMapDefaultL :: forall f a m. (Foldable f, Monoid m) =>
-                   (a -> m) -> f a -> m
-foldMapDefaultL f xs = foldl (\acc x -> f x <> acc) mempty xs
-
--- | A default implementation of `foldMap` using `foldr`
+-- | A default implementation of `foldMap` using `foldr`.
 -- |
 -- | Note: when defining a `Foldable` instance, this function is unsafe to use
 -- | in combination with `foldrDefault`.
 foldMapDefaultR :: forall f a m. (Foldable f, Monoid m) =>
                    (a -> m) -> f a -> m
 foldMapDefaultR f xs = foldr (\x acc -> f x <> acc) mempty xs
+
+-- | A default implementation of `foldMap` using `foldl`.
+-- |
+-- | Note: when defining a `Foldable` instance, this function is unsafe to use
+-- | in combination with `foldlDefault`.
+foldMapDefaultL :: forall f a m. (Foldable f, Monoid m) =>
+                   (a -> m) -> f a -> m
+foldMapDefaultL f xs = foldl (\acc x -> f x <> acc) mempty xs
 
 
 instance foldableArray :: Foldable Array where

--- a/src/Data/Foldable.purs
+++ b/src/Data/Foldable.purs
@@ -1,5 +1,6 @@
 module Data.Foldable
   ( Foldable, foldr, foldl, foldMap
+  , foldrDefault, foldlDefault, foldMapDefaultL, foldMapDefaultR
   , fold
   , traverse_
   , for_
@@ -25,7 +26,8 @@ import Data.Maybe.First (First(..), runFirst)
 import Data.Maybe.Last (Last(..))
 import Data.Monoid (Monoid, mempty)
 import Data.Monoid.Additive (Additive(..))
-import Data.Monoid.Dual (Dual(..))
+import Data.Monoid.Dual (Dual(..), runDual)
+import Data.Monoid.Endo (Endo(..), runEndo)
 import Data.Monoid.Disj (Disj(..), runDisj)
 import Data.Monoid.Conj (Conj(..), runConj)
 import Data.Monoid.Multiplicative (Multiplicative(..))
@@ -40,10 +42,32 @@ class Foldable f where
   foldl :: forall a b. (b -> a -> b) -> b -> f a -> b
   foldMap :: forall a m. (Monoid m) => (a -> m) -> f a -> m
 
+
+-- | A default implementation of `foldr` using `foldMap`
+foldrDefault :: forall f a b. (Foldable f) =>
+                (a -> b -> b) -> b -> f a -> b
+foldrDefault c u xs = runEndo (foldMap (Endo <<< c) xs) u
+
+-- | A default implementation of `foldl` using `foldMap`
+foldlDefault :: forall f a b. (Foldable f) =>
+                (b -> a -> b) -> b -> f a -> b
+foldlDefault c u xs = runEndo (runDual (foldMap (Dual <<< Endo <<< flip c) xs)) u
+
+-- | A default implementation of `foldMap` using `foldl`
+foldMapDefaultL :: forall f a m. (Foldable f, Monoid m) =>
+                   (a -> m) -> f a -> m
+foldMapDefaultL f xs = foldl (\acc x -> f x <> acc) mempty xs
+
+-- | A default implementation of `foldMap` using `foldr`
+foldMapDefaultR :: forall f a m. (Foldable f, Monoid m) =>
+                   (a -> m) -> f a -> m
+foldMapDefaultR f xs = foldr (\x acc -> f x <> acc) mempty xs
+
+
 instance foldableArray :: Foldable Array where
-  foldr = foldrArray
-  foldl = foldlArray
-  foldMap f xs = foldr (\x acc -> f x <> acc) mempty xs
+  foldr   = foldrArray
+  foldl   = foldlArray
+  foldMap = foldMapDefaultR
 
 foreign import foldrArray :: forall a b. (a -> b -> b) -> b -> Array a -> b
 foreign import foldlArray :: forall a b. (b -> a -> b) -> b -> Array a -> b

--- a/src/Data/Foldable.purs
+++ b/src/Data/Foldable.purs
@@ -37,6 +37,17 @@ import Data.Monoid.Multiplicative (Multiplicative(..))
 -- | - `foldr` folds a structure from the right
 -- | - `foldl` folds a structure from the left
 -- | - `foldMap` folds a structure by accumulating values in a `Monoid`
+-- |
+-- | Default implementations are provided by the following functions:
+-- |
+-- | - `foldrDefault`
+-- | - `foldlDefault`
+-- | - `foldMapDefaultL`
+-- | - `foldMapDefaultR`
+-- |
+-- | Note: that some combinations of the default implementations are unsafe to
+-- | use together - causing a non-terminating mutually recursive cycle.
+-- | These combinations are documented per function.
 class Foldable f where
   foldr :: forall a b. (a -> b -> b) -> b -> f a -> b
   foldl :: forall a b. (b -> a -> b) -> b -> f a -> b
@@ -44,21 +55,33 @@ class Foldable f where
 
 
 -- | A default implementation of `foldr` using `foldMap`
+-- |
+-- | Note: when defining a `Foldable` instance, this function is unsafe to use
+-- | in combination with `foldMapDefaultR`.
 foldrDefault :: forall f a b. (Foldable f) =>
                 (a -> b -> b) -> b -> f a -> b
 foldrDefault c u xs = runEndo (foldMap (Endo <<< c) xs) u
 
 -- | A default implementation of `foldl` using `foldMap`
+-- |
+-- | Note: when defining a `Foldable` instance, this function is unsafe to use
+-- | in combination with `foldMapDefaultL`.
 foldlDefault :: forall f a b. (Foldable f) =>
                 (b -> a -> b) -> b -> f a -> b
 foldlDefault c u xs = runEndo (runDual (foldMap (Dual <<< Endo <<< flip c) xs)) u
 
 -- | A default implementation of `foldMap` using `foldl`
+-- |
+-- | Note: when defining a `Foldable` instance, this function is unsafe to use
+-- | in combination with `foldlDefault`.
 foldMapDefaultL :: forall f a m. (Foldable f, Monoid m) =>
                    (a -> m) -> f a -> m
 foldMapDefaultL f xs = foldl (\acc x -> f x <> acc) mempty xs
 
 -- | A default implementation of `foldMap` using `foldr`
+-- |
+-- | Note: when defining a `Foldable` instance, this function is unsafe to use
+-- | in combination with `foldrDefault`.
 foldMapDefaultR :: forall f a m. (Foldable f, Monoid m) =>
                    (a -> m) -> f a -> m
 foldMapDefaultR f xs = foldr (\x acc -> f x <> acc) mempty xs

--- a/src/Data/Traversable.purs
+++ b/src/Data/Traversable.purs
@@ -39,6 +39,11 @@ import Data.Monoid.Conj (Conj(..), runConj)
 -- | `Foldable` instances, in the following sense:
 -- |
 -- | - `foldMap f = runConst <<< traverse (Const <<< f)`
+-- |
+-- | Default implementations are provided by the following functions:
+-- |
+-- | - `traverseDefault`
+-- | - `sequenceDefault`
 class (Functor t, Foldable t) <= Traversable t where
   traverse :: forall a b m. (Applicative m) => (a -> m b) -> t a -> m (t b)
   sequence :: forall a m. (Applicative m) => t (m a) -> m (t a)

--- a/src/Data/Traversable.purs
+++ b/src/Data/Traversable.purs
@@ -49,12 +49,14 @@ class (Functor t, Foldable t) <= Traversable t where
   sequence :: forall a m. (Applicative m) => t (m a) -> m (t a)
 
 
--- | A default implementation of `traverse` using `sequence` and `map`
-traverseDefault :: forall t a b m. (Traversable t, Applicative m) => (a -> m b) -> t a -> m (t b)
+-- | A default implementation of `traverse` using `sequence` and `map`.
+traverseDefault :: forall t a b m. (Traversable t, Applicative m) =>
+                   (a -> m b) -> t a -> m (t b)
 traverseDefault f ta = sequence (map f ta)
 
--- | A default implementation of `sequence` using `traverse`
-sequenceDefault :: forall t a m. (Traversable t, Applicative m) => t (m a) -> m (t a)
+-- | A default implementation of `sequence` using `traverse`.
+sequenceDefault :: forall t a m. (Traversable t, Applicative m) =>
+                   t (m a) -> m (t a)
 sequenceDefault tma = traverse id tma
 
 

--- a/src/Data/Traversable.purs
+++ b/src/Data/Traversable.purs
@@ -1,7 +1,6 @@
 module Data.Traversable
-  ( Traversable
-  , traverse
-  , sequence
+  ( Traversable, traverse, sequence
+  , traverseDefault, sequenceDefault
   , for
   , Accum()
   , scanl
@@ -44,6 +43,16 @@ class (Functor t, Foldable t) <= Traversable t where
   traverse :: forall a b m. (Applicative m) => (a -> m b) -> t a -> m (t b)
   sequence :: forall a m. (Applicative m) => t (m a) -> m (t a)
 
+
+-- | A default implementation of `traverse` using `sequence` and `map`
+traverseDefault :: forall t a b m. (Traversable t, Applicative m) => (a -> m b) -> t a -> m (t b)
+traverseDefault f ta = sequence (map f ta)
+
+-- | A default implementation of `sequence` using `traverse`
+sequenceDefault :: forall t a m. (Traversable t, Applicative m) => t (m a) -> m (t a)
+sequenceDefault tma = traverse id tma
+
+
 foreign import traverseArrayImpl
   :: forall m a b. (m (a -> b) -> m a -> m b) ->
                    ((a -> b) -> m a -> m b) ->
@@ -54,7 +63,7 @@ foreign import traverseArrayImpl
 
 instance traversableArray :: Traversable Array where
   traverse = traverseArrayImpl apply map pure
-  sequence = traverse id
+  sequence = sequenceDefault
 
 instance traversableMaybe :: Traversable Maybe where
   traverse _ Nothing  = pure Nothing

--- a/test/Main.purs
+++ b/test/Main.purs
@@ -4,10 +4,13 @@ import Prelude
 
 import Control.Monad.Eff (Eff())
 import Control.Monad.Eff.Console
-import Data.Foldable
 import Data.Maybe
 import Data.Monoid.Additive
+import Data.Foldable
 import Data.Traversable
+import Data.Bifoldable
+import Data.Bifunctor
+import Data.Bitraversable
 import Test.Assert
 
 foreign import arrayFrom1UpTo :: Int -> Array Int
@@ -16,14 +19,8 @@ main = do
   log "Test foldableArray instance"
   testFoldableArrayWith 20
 
-  log "Test traversableArray instance"
-  testTraversableArrayWith 20
-
   log "Test foldableArray instance is stack safe"
   testFoldableArrayWith 20000
-
-  log "Test traversableArray instance is stack safe"
-  testTraversableArrayWith 20000
 
   log "Test foldMapDefaultL"
   testFoldableFoldMapDefaultL 20
@@ -37,11 +34,23 @@ main = do
   log "Test foldrDefault"
   testFoldableFoldlDefault 20
 
+  log "Test traversableArray instance"
+  testTraversableArrayWith 20
+
+  log "Test traversableArray instance is stack safe"
+  testTraversableArrayWith 20000
+
   log "Test traverseDefault"
   testTraverseDefault 20
 
   log "Test sequenceDefault"
   testSequenceDefault 20
+
+  log "Test Bifoldable on `inclusive or`"
+  testBifoldableIOrWith 10 100 42
+
+  log "Test Bitraversable on `inclusive or`"
+  testBitraversableIOr
 
   log "All done!"
 
@@ -49,12 +58,12 @@ main = do
 testFoldableFWith :: forall f e. (Foldable f, Eq (f Int)) =>
                      (Int -> f Int) -> Int -> Eff (assert :: ASSERT | e) Unit
 testFoldableFWith f n = do
-  let arr = f n
+  let dat = f n
   let expectedSum = (n / 2) * (n + 1)
 
-  assert $ foldr (+) 0 arr == expectedSum
-  assert $ foldl (+) 0 arr == expectedSum
-  assert $ foldMap Additive arr == Additive expectedSum
+  assert $ foldr (+) 0 dat == expectedSum
+  assert $ foldl (+) 0 dat == expectedSum
+  assert $ foldMap Additive dat == Additive expectedSum
 
 testFoldableArrayWith = testFoldableFWith arrayFrom1UpTo
 
@@ -62,12 +71,12 @@ testFoldableArrayWith = testFoldableFWith arrayFrom1UpTo
 testTraversableFWith :: forall f e. (Traversable f, Eq (f Int)) =>
                         (Int -> f Int) -> Int -> Eff (assert :: ASSERT | e) Unit
 testTraversableFWith f n = do
-  let arr = f n
+  let dat = f n
 
-  assert $ traverse Just arr == Just arr
-  assert $ traverse return arr == [arr]
-  assert $ traverse (\x -> if x < 10 then Just x else Nothing) arr == Nothing
-  assert $ sequence (map Just arr) == traverse Just arr
+  assert $ traverse Just dat == Just dat
+  assert $ traverse return dat == [dat]
+  assert $ traverse (\x -> if x < 10 then Just x else Nothing) dat == Nothing
+  assert $ sequence (map Just dat) == traverse Just dat
 
 testTraversableArrayWith = testTraversableFWith arrayFrom1UpTo
 
@@ -145,4 +154,65 @@ instance traversableSD :: Traversable SequenceDefault where
 
 testTraverseDefault = testTraversableFWith (TD <<< arrayFrom1UpTo)
 testSequenceDefault = testTraversableFWith (SD <<< arrayFrom1UpTo)
+
+
+-- structure for testing bifoldable, picked `inclusive or` as it has both products and sums
+
+data IOr l r = Both l r | Fst l | Snd r
+
+instance eqIOr :: (Eq l, Eq r) => Eq (IOr l r) where
+  eq (Both lFst lSnd) (Both rFst rSnd) = (lFst == rFst) && (lSnd == rSnd)
+  eq (Fst l)          (Fst r)          = l == r
+  eq (Snd l)          (Snd r)          = l == r
+  eq _                _                = false
+
+instance bifoldableIOr :: Bifoldable IOr where
+  bifoldr l r u (Both fst snd) = l fst (r snd u)
+  bifoldr l r u (Fst fst)      = l fst u
+  bifoldr l r u (Snd snd)      = r snd u
+
+  bifoldl l r u (Both fst snd) = r (l u fst) snd
+  bifoldl l r u (Fst fst)      = l u fst
+  bifoldl l r u (Snd snd)      = r u snd
+
+  bifoldMap l r (Both fst snd) = l fst <> r snd
+  bifoldMap l r (Fst fst)      = l fst
+  bifoldMap l r (Snd snd)      = r snd
+
+instance bifunctorIOr :: Bifunctor IOr where
+  bimap f g (Both fst snd) = Both (f fst) (g snd)
+  bimap f g (Fst fst)      = Fst (f fst)
+  bimap f g (Snd snd)      = Snd (g snd)
+
+instance bitraversableIOr :: Bitraversable IOr where
+  bitraverse f g (Both fst snd) = Both <$> f fst <*> g snd
+  bitraverse f g (Fst fst)      = Fst <$> f fst
+  bitraverse f g (Snd snd)      = Snd <$> g snd
+
+  bisequence (Both fst snd) = Both <$> fst <*> snd
+  bisequence (Fst fst)      = Fst <$> fst
+  bisequence (Snd snd)      = Snd <$> snd
+
+testBifoldableIOrWith :: forall e. Int -> Int -> Int -> Eff (assert :: ASSERT | e) Unit
+testBifoldableIOrWith fst snd u = do
+  assert $ bifoldr (+) (*) u (Both fst snd) == fst + (snd * u)
+  assert $ bifoldr (+) (*) u (Fst fst)      == fst + u
+  assert $ bifoldr (+) (*) u (Snd snd)      == snd * u
+
+  assert $ bifoldl (+) (*) u (Both fst snd) == (u + fst) * snd
+  assert $ bifoldl (+) (*) u (Fst fst)      == u + fst
+  assert $ bifoldl (+) (*) u (Snd snd)      == u * snd
+
+  assert $ bifoldMap Additive Additive (Both fst snd) == Additive (fst + snd)
+  assert $ bifoldMap Additive Additive (Fst fst)      == Additive fst
+  assert $ bifoldMap Additive Additive (Snd snd)      == Additive snd
+
+testBitraversableIOr :: forall e. Eff (assert :: ASSERT | e) Unit
+testBitraversableIOr = do
+  assert $ bisequence (Both (Just true) (Just false)) == Just (Both true false)
+  assert $ bisequence (Fst (Just true))               == Just (Fst true  :: IOr Boolean Boolean)
+  assert $ bisequence (Snd (Just false))              == Just (Snd false :: IOr Boolean Boolean)
+  assert $ bitraverse Just Just (Both true false)     == Just (Both true false)
+  assert $ bitraverse Just Just (Fst true)            == Just (Fst true  :: IOr Boolean Boolean)
+  assert $ bitraverse Just Just (Snd false)           == Just (Snd false :: IOr Boolean Boolean)
 

--- a/test/Main.purs
+++ b/test/Main.purs
@@ -1,8 +1,8 @@
-
 module Test.Main where
 
 import Prelude
 
+import Control.Monad.Eff (Eff())
 import Control.Monad.Eff.Console
 import Data.Foldable
 import Data.Maybe
@@ -14,30 +14,133 @@ foreign import arrayFrom1UpTo :: Int -> Array Int
 
 main = do
   log "Test foldableArray instance"
-  testFoldableWith 20
+  testFoldableArrayWith 20
 
   log "Test traversableArray instance"
-  testTraversableWith 20
+  testTraversableArrayWith 20
 
   log "Test foldableArray instance is stack safe"
-  testFoldableWith 20000
+  testFoldableArrayWith 20000
 
   log "Test traversableArray instance is stack safe"
-  testTraversableWith 20000
+  testTraversableArrayWith 20000
+
+  log "Test foldMapDefaultL"
+  testFoldableFoldMapDefaultL 20
+
+  log "Test foldMapDefaultR"
+  testFoldableFoldMapDefaultR 20
+
+  log "Test foldlDefault"
+  testFoldableFoldlDefault 20
+
+  log "Test foldrDefault"
+  testFoldableFoldlDefault 20
+
+  log "Test traverseDefault"
+  testTraverseDefault 20
+
+  log "Test sequenceDefault"
+  testSequenceDefault 20
 
   log "All done!"
 
-testFoldableWith n = do
-  let arr = arrayFrom1UpTo n
+
+testFoldableFWith :: forall f e. (Foldable f, Eq (f Int)) => (Int -> f Int) -> Int -> Eff (assert :: ASSERT | e) Unit
+testFoldableFWith f n = do
+  let arr = f n
   let expectedSum = (n / 2) * (n + 1)
 
   assert $ foldr (+) 0 arr == expectedSum
   assert $ foldl (+) 0 arr == expectedSum
   assert $ foldMap Additive arr == Additive expectedSum
 
-testTraversableWith n = do
-  let arr = arrayFrom1UpTo n
+testFoldableArrayWith = testFoldableFWith arrayFrom1UpTo
+
+
+testTraversableFWith :: forall f e. (Traversable f, Eq (f Int)) => (Int -> f Int) -> Int -> Eff (assert :: ASSERT | e) Unit
+testTraversableFWith f n = do
+  let arr = f n
 
   assert $ traverse Just arr == Just arr
   assert $ traverse return arr == [arr]
   assert $ traverse (\x -> if x < 10 then Just x else Nothing) arr == Nothing
+  assert $ sequence (map Just arr) == traverse Just arr
+
+testTraversableArrayWith = testTraversableFWith arrayFrom1UpTo
+
+
+-- structures for testing default `Foldable` implementations
+
+newtype FoldMapDefaultL a = FML (Array a)
+newtype FoldMapDefaultR a = FMR (Array a)
+newtype FoldlDefault    a = FLD (Array a)
+newtype FoldrDefault    a = FRD (Array a)
+
+instance eqFML :: (Eq a) => Eq (FoldMapDefaultL a) where eq (FML l) (FML r) = l == r
+instance eqFMR :: (Eq a) => Eq (FoldMapDefaultR a) where eq (FMR l) (FMR r) = l == r
+instance eqFLD :: (Eq a) => Eq (FoldlDefault a)    where eq (FLD l) (FLD r) = l == r
+instance eqFRD :: (Eq a) => Eq (FoldrDefault a)    where eq (FRD l) (FRD r) = l == r
+
+-- implemented `foldl` and `foldr`, but default `foldMap` using `foldl`
+instance foldableFML :: Foldable FoldMapDefaultL where
+  foldMap f         = foldMapDefaultL f
+  foldl f u (FML a) = foldl f u a
+  foldr f u (FML a) = foldr f u a
+
+-- implemented `foldl` and `foldr`, but default `foldMap`, using `foldr`
+instance foldableFMR :: Foldable FoldMapDefaultR where
+  foldMap f         = foldMapDefaultR f
+  foldl f u (FMR a) = foldl f u a
+  foldr f u (FMR a) = foldr f u a
+
+-- implemented `foldMap` and `foldr`, but default `foldMap`
+instance foldableDFL :: Foldable FoldlDefault where
+  foldMap f (FLD a) = foldMap f a
+  foldl f u         = foldlDefault f u
+  foldr f u (FLD a) = foldr f u a
+
+-- implemented `foldMap` and `foldl`, but default `foldr`
+instance foldableDFR :: Foldable FoldrDefault where
+  foldMap f (FRD a) = foldMap f a
+  foldl f u (FRD a) = foldl f u a
+  foldr f u         = foldrDefault f u
+
+testFoldableFoldMapDefaultL = testFoldableFWith (FML <<< arrayFrom1UpTo)
+testFoldableFoldMapDefaultR = testFoldableFWith (FMR <<< arrayFrom1UpTo)
+testFoldableFoldlDefault    = testFoldableFWith (FLD <<< arrayFrom1UpTo)
+testFoldableFoldrDefault    = testFoldableFWith (FRD <<< arrayFrom1UpTo)
+
+
+-- structures for testing default `Traversable` implementations
+
+newtype TraverseDefault a = TD (Array a)
+newtype SequenceDefault a = SD (Array a)
+
+instance eqTD :: (Eq a) => Eq (TraverseDefault a) where eq (TD l) (TD r) = l == r
+instance eqSD :: (Eq a) => Eq (SequenceDefault a) where eq (SD l) (SD r) = l == r
+
+instance functorTD :: Functor TraverseDefault where map f (TD a) = TD (map f a)
+instance functorSD :: Functor SequenceDefault where map f (SD a) = SD (map f a)
+
+instance foldableTD :: Foldable TraverseDefault where
+  foldMap f (TD a) = foldMap f a
+  foldr f u (TD a) = foldr f u a
+  foldl f u (TD a) = foldl f u a
+
+instance foldableSD :: Foldable SequenceDefault where
+  foldMap f (SD a) = foldMap f a
+  foldr f u (SD a) = foldr f u a
+  foldl f u (SD a) = foldl f u a
+
+instance traversableTD :: Traversable TraverseDefault where
+  traverse f      = traverseDefault f
+  sequence (TD a) = map TD (sequence a)
+
+instance traversableSD :: Traversable SequenceDefault where
+  traverse f (SD a) = map SD (traverse f a)
+  sequence m        = sequenceDefault m
+
+testTraverseDefault = testTraversableFWith (TD <<< arrayFrom1UpTo)
+testSequenceDefault = testTraversableFWith (SD <<< arrayFrom1UpTo)
+

--- a/test/Main.purs
+++ b/test/Main.purs
@@ -46,7 +46,8 @@ main = do
   log "All done!"
 
 
-testFoldableFWith :: forall f e. (Foldable f, Eq (f Int)) => (Int -> f Int) -> Int -> Eff (assert :: ASSERT | e) Unit
+testFoldableFWith :: forall f e. (Foldable f, Eq (f Int)) =>
+                     (Int -> f Int) -> Int -> Eff (assert :: ASSERT | e) Unit
 testFoldableFWith f n = do
   let arr = f n
   let expectedSum = (n / 2) * (n + 1)
@@ -58,7 +59,8 @@ testFoldableFWith f n = do
 testFoldableArrayWith = testFoldableFWith arrayFrom1UpTo
 
 
-testTraversableFWith :: forall f e. (Traversable f, Eq (f Int)) => (Int -> f Int) -> Int -> Eff (assert :: ASSERT | e) Unit
+testTraversableFWith :: forall f e. (Traversable f, Eq (f Int)) =>
+                        (Int -> f Int) -> Int -> Eff (assert :: ASSERT | e) Unit
 testTraversableFWith f n = do
   let arr = f n
 


### PR DESCRIPTION
[Ticket #27](https://github.com/purescript/purescript-foldable-traversable/issues/27)

Functions added:

* foldMapDefaultL
* foldMapDefaultR
* foldlDefault
* foldrDefault
* traverseDefault
* sequenceDefault

Added tests for each new function.

Plus regenerated docs.

---

Added two `foldMap` defaults because if you're using the defaults you'll probably only implement one of the three methods and if you only had `foldMapDefault` defined in terms of `foldr` and tried to use both `foldrDefault` and `foldMapDefault`, you'd get a stack overflow due to non-termination (which I got initially when writing the tests).  So now you can pick `foldMapDefaultL`/`foldMapDefaultR`, which are respectively defined in terms of `foldl`/`foldr`.

Any thoughts/feedback?