### PR TITLE
Update docs for `any` and `all`

### DIFF
--- a/docs/Data/Foldable.md
+++ b/docs/Data/Foldable.md
@@ -178,21 +178,23 @@ The disjunction of all the values in a data structure. When specialized
 to `Boolean`, this function will test whether any of the values in a data
 structure is `true`.
 
-#### `any`
-
-``` purescript
-any :: forall a b f. (Foldable f, BooleanAlgebra b) => (a -> b) -> f a -> b
-```
-
-Test whether a predicate holds for any element in a data structure.
-
 #### `all`
 
 ``` purescript
 all :: forall a b f. (Foldable f, BooleanAlgebra b) => (a -> b) -> f a -> b
 ```
 
-Test whether a predicate holds for all elements in a data structure.
+`all f` is the same as `and <<< map f`; map a function over the structure,
+and then get the conjunction of the results.
+
+#### `any`
+
+``` purescript
+any :: forall a b f. (Foldable f, BooleanAlgebra b) => (a -> b) -> f a -> b
+```
+
+`any f` is the same as `or <<< map f`; map a function over the structure,
+and then get the disjunction of the results.
 
 #### `sum`
 

--- a/src/Data/Foldable.purs
+++ b/src/Data/Foldable.purs
@@ -9,8 +9,8 @@ module Data.Foldable
   , intercalate
   , and
   , or
-  , any
   , all
+  , any
   , sum
   , product
   , elem
@@ -209,13 +209,15 @@ and = all id
 or :: forall a f. (Foldable f, BooleanAlgebra a) => f a -> a
 or = any id
 
--- | Test whether a predicate holds for any element in a data structure.
-any :: forall a b f. (Foldable f, BooleanAlgebra b) => (a -> b) -> f a -> b
-any p = runDisj <<< foldMap (Disj <<< p)
-
--- | Test whether a predicate holds for all elements in a data structure.
+-- | `all f` is the same as `and <<< map f`; map a function over the structure,
+-- | and then get the conjunction of the results.
 all :: forall a b f. (Foldable f, BooleanAlgebra b) => (a -> b) -> f a -> b
 all p = runConj <<< foldMap (Conj <<< p)
+
+-- | `any f` is the same as `or <<< map f`; map a function over the structure,
+-- | and then get the disjunction of the results.
+any :: forall a b f. (Foldable f, BooleanAlgebra b) => (a -> b) -> f a -> b
+any p = runDisj <<< foldMap (Disj <<< p)
 
 -- | Find the sum of the numeric values in a data structure.
 sum :: forall a f. (Foldable f, Semiring a) => f a -> a


### PR DESCRIPTION
I also switched them over, because I think this order makes more sense - if `and` comes before `or`, then `all` should come before `any`.