### PR TITLE
Remove mconcat. fixes #41

### DIFF
--- a/docs/Data/Foldable.md
+++ b/docs/Data/Foldable.md
@@ -141,14 +141,6 @@ For example:
 sequence_ [ trace "Hello, ", trace " world!" ]
 ```
 
-#### `mconcat`
-
-``` purescript
-mconcat :: forall f m. (Foldable f, Monoid m) => f m -> m
-```
-
-Fold a data structure, accumulating values in some `Monoid`.
-
 #### `intercalate`
 
 ``` purescript

--- a/src/Data/Foldable.purs
+++ b/src/Data/Foldable.purs
@@ -5,7 +5,6 @@ module Data.Foldable
   , traverse_
   , for_
   , sequence_
-  , mconcat
   , intercalate
   , and
   , or
@@ -184,10 +183,6 @@ for_ = flip traverse_
 -- | ```
 sequence_ :: forall a f m. (Applicative m, Foldable f) => f (m a) -> m Unit
 sequence_ = traverse_ id
-
--- | Fold a data structure, accumulating values in some `Monoid`.
-mconcat :: forall f m. (Foldable f, Monoid m) => f m -> m
-mconcat = foldl (<>) mempty
 
 -- | Fold a data structure, accumulating values in some `Monoid`,
 -- | combining adjacent elements using the specified separator.


### PR DESCRIPTION
I did say "deprecate" earlier, but since we don't really have any way of doing that (aside: this might be nice to have?), I just removed it outright.