### PR TITLE
Better `find` behaviour and performance

### DIFF
--- a/src/Data/Foldable.purs
+++ b/src/Data/Foldable.purs
@@ -271,7 +271,10 @@ notElem x = not <<< elem x
 
 -- | Try to find an element in a data structure which satisfies a predicate.
 find :: forall a f. Foldable f => (a -> Boolean) -> f a -> Maybe a
-find p = foldl (\r x -> if p x then Just x else r) Nothing
+find p = foldl go Nothing
+  where
+  go Nothing x | p x = Just x
+  go r _ = r
 
 -- | Find the largest element of a structure, according to its `Ord` instance.
 maximum :: forall a f. (Ord a, Foldable f) => f a -> Maybe a

--- a/test/Main.purs
+++ b/test/Main.purs
@@ -8,7 +8,7 @@ import Control.Monad.Eff.Console (CONSOLE, log)
 import Data.Bifoldable (class Bifoldable, bifoldl, bifoldr, bifoldMap, bifoldrDefault, bifoldlDefault, bifoldMapDefaultR, bifoldMapDefaultL)
 import Data.Bifunctor (class Bifunctor, bimap)
 import Data.Bitraversable (class Bitraversable, bisequenceDefault, bitraverse, bisequence, bitraverseDefault)
-import Data.Foldable (class Foldable, foldl, foldr, foldMap, foldrDefault, foldlDefault, foldMapDefaultR, foldMapDefaultL, minimumBy, minimum, maximumBy, maximum)
+import Data.Foldable (class Foldable, foldl, foldr, foldMap, foldrDefault, foldlDefault, foldMapDefaultR, foldMapDefaultL, minimumBy, minimum, maximumBy, maximum, find)
 import Data.Function (on)
 import Data.Int (toNumber)
 import Data.Maybe (Maybe(..))
@@ -76,6 +76,10 @@ main = do
 
   log "Test bisequenceDefault"
   testBitraversableIOrWith BSD
+
+  log "Test find"
+  assert $ find (_ == 10) [1, 5, 10] == Just 10
+  assert $ find (\x -> x `mod` 2 == 0) [1, 4, 10] == Just 4
 
   log "Test maximum"
   assert $ maximum (arrayFrom1UpTo 10) == Just 10
@@ -339,4 +343,3 @@ instance bitraversableBTD :: Bitraversable BitraverseDefault where
 instance bitraversableBSD :: Bitraversable BisequenceDefault where
   bitraverse f g (BSD m) = map BSD (bitraverse f g m)
   bisequence m           = bisequenceDefault m
-


### PR DESCRIPTION
This will result in `find` returning the first value to match a predicate rather than the last, and now the predicate is only run until the first match rather than on every item in the structure.

/cc @natefaubion @jonsterling