### PR TITLE
Divide and conquer array traverse

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -24,6 +24,7 @@
     "purescript-assert": "^2.0.0",
     "purescript-console": "^2.0.0",
     "purescript-integers": "^2.0.0",
-    "purescript-math": "^2.0.0"
+    "purescript-math": "^2.0.0",
+    "purescript-unsafe-coerce": "^2.0.0"
   }
 }

--- a/src/Data/Traversable.js
+++ b/src/Data/Traversable.js
@@ -3,58 +3,32 @@
 // jshint maxparams: 3
 
 exports.traverseArrayImpl = function () {
-  function Cont(fn) {
-    this.fn = fn;
+  function array1(a) {return [a];}
+
+  function array2(a) {
+    return function (b) {return [a, b];};
   }
 
-  var emptyList = {};
-
-  var ConsCell = function (head, tail) {
-    this.head = head;
-    this.tail = tail;
-  };
-
-  function consList(x) {
-    return function (xs) {
-      return new ConsCell(x, xs);
-    };
-  }
-
-  function listToArray(list) {
-    var arr = [];
-    while (list !== emptyList) {
-      arr.push(list.head);
-      list = list.tail;
-    }
-    return arr;
+  function concat2(xs) {
+    return function (ys) {return xs.concat(ys);};
   }
 
   return function (apply) {
     return function (map) {
       return function (pure) {
         return function (f) {
-          var buildFrom = function (x, ys) {
-            return apply(map(consList)(f(x)))(ys);
-          };
-
-          var go = function (acc, currentLen, xs) {
-            if (currentLen === 0) {
-              return acc;
-            } else {
-              var last = xs[currentLen - 1];
-              return new Cont(function () {
-                return go(buildFrom(last, acc), currentLen - 1, xs);
-              });
-            }
-          };
-
           return function (array) {
-            var result = go(pure(emptyList), array.length, array);
-            while (result instanceof Cont) {
-              result = result.fn();
+            function go(bot, top) {
+              switch (top - bot) {
+              case 0: return pure([]);
+              case 1: return map(array1)(f(array[bot]));
+              case 2: return apply(map(array2)(f(array[bot])))(f(array[bot + 1]));
+              default:
+                var pivot = bot + Math.floor((top - bot) / 4) * 2;
+                return apply(map(concat2)(go(bot, pivot)))(go(pivot, top));
+              }
             }
-
-            return map(listToArray)(result);
+            return go(0, array.length);
           };
         };
       };

--- a/src/Data/Traversable.js
+++ b/src/Data/Traversable.js
@@ -24,7 +24,7 @@ exports.traverseArrayImpl = function () {
               case 1: return map(array1)(f(array[bot]));
               case 2: return apply(map(array2)(f(array[bot])))(f(array[bot + 1]));
               default:
-                var pivot = bot + Math.floor((top - bot) / 4) * 2;
+                var pivot = Math.floor((top + bot) / 2);
                 return apply(map(concat2)(go(bot, pivot)))(go(pivot, top));
               }
             }

--- a/test/Main.js
+++ b/test/Main.js
@@ -7,3 +7,19 @@ exports.arrayFrom1UpTo = function (n) {
   }
   return result;
 };
+
+exports.arrayReplicate = function (n) {
+  return function (x) {
+    var result = [];
+    for (var i = 1; i <= n; i++) {
+      result.push(x);
+    }
+    return result;
+  };
+};
+
+exports.intPow = function (x) {
+  return function (y) {
+    return Math.pow(x,y) | 0;
+  };
+};

--- a/test/Main.purs
+++ b/test/Main.purs
@@ -129,6 +129,7 @@ testTraversableFWith f n = do
   assert $ traverse pure dat == [dat]
   assert $ traverse (\x -> if x < 10 then Just x else Nothing) dat == Nothing
   assert $ sequence (map Just dat) == traverse Just dat
+  assert $ (traverse pure dat :: Unit -> f Int) unit == dat
 
 testTraversableArrayWith :: forall eff. Int -> Eff (assert :: ASSERT | eff) Unit
 testTraversableArrayWith = testTraversableFWith arrayFrom1UpTo


### PR DESCRIPTION
Port of scalaz/scalaz#1023, as explained there.

Includes test that fails the stack-safety check with previous `traverseArrayImpl`, but passes with this one.

Original discussion from IRC:

```
[2016-03-31 16:57:54]
<S11001001> (I mean [Array] should probably be divide-and-conquer but what do I know about JS allocation efficiency)
<hdgarrood> the array one used to be quadratic, even, I fixed that a while ago
<hdgarrood> oh in stack, right, sorry
<hdgarrood> S11001001: what do you mean by divide-and-conquer?
<S11001001> hdgarrood: if you traverse the halves, then liftA2 (<>)
<S11001001> hdgarrood: whether that's more efficient than going via a cons list I'm not sure; in some VMs it certainly is
<thimoteus> https://en.wikipedia.org/wiki/Divide_and_conquer_algorithms
<hdgarrood> Ah, I see. Do you still traverse in the right order though?
<S11001001> hdgarrood: yeah, you end up with equal results because <*> is associative
<hdgarrood> ah of course
<hdgarrood> if you do an implementation I'd happily set a benchmark up
<S11001001> hdgarrood: k
<hdgarrood> so that's logarithmic stack then?
 <S11001001> hdgarrood: yep
[2016-03-31 17:01:30]
```
