### PR TITLE
Iterable typeclass.

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -18,7 +18,9 @@
   ],
   "dependencies": {
     "purescript-bifunctors": "^3.0.0",
-    "purescript-maybe": "^3.0.0"
+    "purescript-maybe": "^3.0.0",
+    "purescript-eff": "^3.1.0",
+    "purescript-unsafe-coerce": "^3.0.0"
   },
   "devDependencies": {
     "purescript-assert": "^3.0.0",

--- a/src/Data/Iterable.purs
+++ b/src/Data/Iterable.purs
@@ -1,0 +1,70 @@
+module Data.Iterable where
+
+import Prelude
+import Control.Monad.Eff (Eff, foreachE)
+import Data.Foldable (traverse_)
+import Data.Traversable (traverse)
+import Unsafe.Coerce (unsafeCoerce)
+
+import Data.Maybe (Maybe)
+import Data.Maybe.First (First)
+import Data.Maybe.Last (Last)
+import Data.Monoid.Additive (Additive)
+import Data.Monoid.Conj (Conj)
+import Data.Monoid.Disj (Disj)
+import Data.Monoid.Dual (Dual)
+import Data.Monoid.Multiplicative (Multiplicative)
+
+-- | `Iterable` represents data structures which can be _traversed_,
+-- | within the Eff monad.
+-- |
+-- | - `forEach` runs an effect for every element in a data structure,
+-- |   and accumulates the results, in the manner of `traverse`.
+-- | - `forEach_` runs an effect for every element in a data structure,
+-- |   without result communication, in the manner of `traverse_`.
+-- |
+-- | While `forEach` and `forEach_` should be functionally equivalent
+-- | to `traverse` and `traverse_`, respectively. The `Iterable` typeclass
+-- | is provided such that optimized versions of these functions may
+-- | be written for the Eff monad. For an example, see `iterableArray`,
+-- | below.
+
+class Iterable i where
+  forEach :: forall eff a b. (a -> Eff eff b) -> i a -> Eff eff (i b)
+  forEach_ :: forall eff a b. (a -> Eff eff b) -> i a -> Eff eff Unit
+
+instance iterableArray :: Iterable Array where
+  forEach_ f a = foreachE a $ unsafeCoerce f
+  forEach = traverse
+
+instance iterableMaybe :: Iterable Maybe where
+  forEach_ = traverse_
+  forEach = traverse
+
+instance iterableFirst :: Iterable First where
+  forEach_ = traverse_
+  forEach = traverse
+
+instance iterableLast :: Iterable Last where
+  forEach_ = traverse_
+  forEach = traverse
+
+instance iterableAdditive :: Iterable Additive where
+  forEach_ = traverse_
+  forEach = traverse
+
+instance iterableDual :: Iterable Dual where
+  forEach_ = traverse_
+  forEach = traverse
+
+instance iterableConj :: Iterable Conj where
+  forEach_ = traverse_
+  forEach = traverse
+
+instance iterableDisj :: Iterable Disj where
+  forEach_ = traverse_
+  forEach = traverse
+
+instance iterableMultiplicative :: Iterable Multiplicative where
+  forEach_ = traverse_
+  forEach = traverse


### PR DESCRIPTION
Following discussion at https://github.com/purescript/purescript-eff/pull/22#discussion_r120930567

The `purescript-unsafe-coerce` dep can be removed if https://github.com/purescript/purescript-eff/pull/23 is accepted.

Would particularly like input on the documentation.

Also, I have not made `Functor` a superclass. I'm happy to change that, but so far I haven't seen anything that makes it a requirement, or beneficial.