### PR TITLE
Fix foldMapDefaultL

### DIFF
--- a/src/Data/Foldable.purs
+++ b/src/Data/Foldable.purs
@@ -115,7 +115,7 @@ foldMapDefaultL
   => (a -> m)
   -> f a
   -> m
-foldMapDefaultL f = foldl (\acc x -> f x <> acc) mempty
+foldMapDefaultL f = foldl (\acc x -> acc <> f x) mempty
 
 instance foldableArray :: Foldable Array where
   foldr = foldrArray

--- a/test/Main.purs
+++ b/test/Main.purs
@@ -26,6 +26,8 @@ main = do
   log "Test foldableArray instance"
   testFoldableArrayWith 20
 
+  assert $ foldMapDefaultL (\x -> [x]) [1, 2] == [1, 2]
+
   log "Test foldableArray instance is stack safe"
   testFoldableArrayWith 20000
 

--- a/test/Main.purs
+++ b/test/Main.purs
@@ -4,17 +4,19 @@ import Prelude
 
 import Control.Monad.Eff (Eff)
 import Control.Monad.Eff.Console (CONSOLE, log)
+
 import Data.Bifoldable (class Bifoldable, bifoldl, bifoldr, bifoldMap, bifoldrDefault, bifoldlDefault, bifoldMapDefaultR, bifoldMapDefaultL)
 import Data.Bifunctor (class Bifunctor, bimap)
 import Data.Bitraversable (class Bitraversable, bisequenceDefault, bitraverse, bisequence, bitraverseDefault)
-import Data.Foldable (class Foldable, find, findMap, fold, foldMap, foldMapDefaultL, foldMapDefaultR, foldl, foldlDefault, foldr, foldrDefault, length, maximum, maximumBy, minimum, minimumBy, null, surroundMap)
+import Data.Foldable (class Foldable, foldl, foldr, foldMap, foldrDefault, foldlDefault, foldMapDefaultR, foldMapDefaultL, minimumBy, minimum, maximumBy, maximum, find, findMap, length, null, surroundMap)
 import Data.Function (on)
 import Data.Int (toNumber)
 import Data.Maybe (Maybe(..))
-import Data.Monoid (class Monoid, mempty)
 import Data.Monoid.Additive (Additive(..))
 import Data.Traversable (class Traversable, sequenceDefault, traverse, sequence, traverseDefault)
+
 import Math (abs)
+
 import Test.Assert (ASSERT, assert)
 
 foreign import arrayFrom1UpTo :: Int -> Array Int
@@ -22,17 +24,22 @@ foreign import arrayFrom1UpTo :: Int -> Array Int
 main :: Eff (console :: CONSOLE, assert :: ASSERT) Unit
 main = do
   log "Test foldableArray instance"
-  assert $ foldMap Additive (arrayFrom1UpTo 20) == Additive (20 * 21 / 2)
-  testFoldableFWith (arrayFrom1UpTo 20) (\x -> [x])
-  testFoldableFWith (arrayFrom1UpTo 20) (\x -> Additive x)
+  testFoldableArrayWith 20
 
   log "Test foldableArray instance is stack safe"
-  -- can't use testFoldableFWith because foldMapDefaultL and -R are not stack
-  -- safe
-  _ <- pure $ foldMap Additive (arrayFrom1UpTo 20000)
-  _ <- pure $ fold (Additive <$> arrayFrom1UpTo 20000)
-  _ <- pure $ foldMapDefaultL Additive (arrayFrom1UpTo 20000)
-  _ <- pure $ foldMapDefaultR Additive (arrayFrom1UpTo 20000)
+  testFoldableArrayWith 20000
+
+  log "Test foldMapDefaultL"
+  testFoldableFoldMapDefaultL 20
+
+  log "Test foldMapDefaultR"
+  testFoldableFoldMapDefaultR 20
+
+  log "Test foldlDefault"
+  testFoldableFoldlDefault 20
+
+  log "Test foldrDefault"
+  testFoldableFoldlDefault 20
 
   log "Test traversableArray instance"
   testTraversableArrayWith 20
@@ -120,21 +127,23 @@ main = do
 
 
 testFoldableFWith
-  :: forall f m a e
+  :: forall f e
    . Foldable f
-  => Functor f
-  => Monoid m
-  => Eq m
-  => f a
-  -> (a -> m)
+  => Eq (f Int)
+  => (Int -> f Int)
+  -> Int
   -> Eff (assert :: ASSERT | e) Unit
-testFoldableFWith n f = do
-  let m = foldMap f n
-  assert $ foldMapDefaultR f n == m
-  assert $ foldMapDefaultL f n == m
-  assert $ foldlDefault (\y x -> y <> f x) mempty n == m
-  assert $ foldrDefault (\x y -> f x <> y) mempty n == m
-  assert $ fold (f <$> n) == m
+testFoldableFWith f n = do
+  let dat = f n
+  let expectedSum = (n / 2) * (n + 1)
+
+  assert $ foldr (+) 0 dat == expectedSum
+  assert $ foldl (+) 0 dat == expectedSum
+  assert $ foldMap Additive dat == Additive expectedSum
+
+testFoldableArrayWith :: forall eff. Int -> Eff (assert :: ASSERT | eff) Unit
+testFoldableArrayWith = testFoldableFWith arrayFrom1UpTo
+
 
 testTraversableFWith
   :: forall f e
@@ -153,6 +162,56 @@ testTraversableFWith f n = do
 
 testTraversableArrayWith :: forall eff. Int -> Eff (assert :: ASSERT | eff) Unit
 testTraversableArrayWith = testTraversableFWith arrayFrom1UpTo
+
+
+-- structures for testing default `Foldable` implementations
+
+newtype FoldMapDefaultL a = FML (Array a)
+newtype FoldMapDefaultR a = FMR (Array a)
+newtype FoldlDefault    a = FLD (Array a)
+newtype FoldrDefault    a = FRD (Array a)
+
+instance eqFML :: (Eq a) => Eq (FoldMapDefaultL a) where eq (FML l) (FML r) = l == r
+instance eqFMR :: (Eq a) => Eq (FoldMapDefaultR a) where eq (FMR l) (FMR r) = l == r
+instance eqFLD :: (Eq a) => Eq (FoldlDefault a)    where eq (FLD l) (FLD r) = l == r
+instance eqFRD :: (Eq a) => Eq (FoldrDefault a)    where eq (FRD l) (FRD r) = l == r
+
+-- implemented `foldl` and `foldr`, but default `foldMap` using `foldl`
+instance foldableFML :: Foldable FoldMapDefaultL where
+  foldMap f         = foldMapDefaultL f
+  foldl f u (FML a) = foldl f u a
+  foldr f u (FML a) = foldr f u a
+
+-- implemented `foldl` and `foldr`, but default `foldMap`, using `foldr`
+instance foldableFMR :: Foldable FoldMapDefaultR where
+  foldMap f         = foldMapDefaultR f
+  foldl f u (FMR a) = foldl f u a
+  foldr f u (FMR a) = foldr f u a
+
+-- implemented `foldMap` and `foldr`, but default `foldMap`
+instance foldableDFL :: Foldable FoldlDefault where
+  foldMap f (FLD a) = foldMap f a
+  foldl f u         = foldlDefault f u
+  foldr f u (FLD a) = foldr f u a
+
+-- implemented `foldMap` and `foldl`, but default `foldr`
+instance foldableDFR :: Foldable FoldrDefault where
+  foldMap f (FRD a) = foldMap f a
+  foldl f u (FRD a) = foldl f u a
+  foldr f u         = foldrDefault f u
+
+testFoldableFoldMapDefaultL :: forall eff. Int -> Eff (assert :: ASSERT | eff) Unit
+testFoldableFoldMapDefaultL = testFoldableFWith (FML <<< arrayFrom1UpTo)
+
+testFoldableFoldMapDefaultR :: forall eff. Int -> Eff (assert :: ASSERT | eff) Unit
+testFoldableFoldMapDefaultR = testFoldableFWith (FMR <<< arrayFrom1UpTo)
+
+testFoldableFoldlDefault :: forall eff. Int -> Eff (assert :: ASSERT | eff) Unit
+testFoldableFoldlDefault = testFoldableFWith (FLD <<< arrayFrom1UpTo)
+
+testFoldableFoldrDefault :: forall eff. Int -> Eff (assert :: ASSERT | eff) Unit
+testFoldableFoldrDefault = testFoldableFWith (FRD <<< arrayFrom1UpTo)
+
 
 -- structures for testing default `Traversable` implementations
 


### PR DESCRIPTION
Previously,
```purescript
foldMapDefaultL singleton [1, 2] = [2, 1]
```
This commit fixes this:
```purescript
  foldMapDefaultL singleton [1, 2]
= foldMapDefaultR singleton [1, 2]
= [1, 2]
```