### PR TITLE
Let findWithIndex also return index of found value

### DIFF
--- a/src/Data/FoldableWithIndex.purs
+++ b/src/Data/FoldableWithIndex.purs
@@ -10,7 +10,6 @@ module Data.FoldableWithIndex
   , surroundMapWithIndex
   , allWithIndex
   , anyWithIndex
-  , ValueWithIndex
   , findWithIndex
   ) where
 
@@ -260,9 +259,6 @@ anyWithIndex
   -> b
 anyWithIndex t = unwrap <<< foldMapWithIndex (\i -> Disj <<< t i)
 
--- | Isomorphic to `Tuple i a`.
-type ValueWithIndex i a = { index :: i, value :: a }
-
 -- | Try to find an element in a data structure which satisfies a predicate
 -- | with access to the index.
 findWithIndex
@@ -270,9 +266,13 @@ findWithIndex
    . FoldableWithIndex i f
   => (i -> a -> Boolean)
   -> f a
-  -> Maybe (ValueWithIndex i a)
+  -> Maybe { index :: i, value :: a}
 findWithIndex p = foldlWithIndex go Nothing
   where
-  go :: i -> Maybe (ValueWithIndex i a) -> a -> Maybe (ValueWithIndex i a)
+  go
+    :: i
+    -> Maybe { index :: i, value :: a}
+    -> a
+    -> Maybe { index :: i, value :: a}
   go i Nothing x | p i x = Just { index: i, value: x}
   go _ r _ = r

--- a/src/Data/FoldableWithIndex.purs
+++ b/src/Data/FoldableWithIndex.purs
@@ -10,6 +10,7 @@ module Data.FoldableWithIndex
   , surroundMapWithIndex
   , allWithIndex
   , anyWithIndex
+  , ValueWithIndex
   , findWithIndex
   ) where
 
@@ -259,6 +260,9 @@ anyWithIndex
   -> b
 anyWithIndex t = unwrap <<< foldMapWithIndex (\i -> Disj <<< t i)
 
+-- | Isomorphic to `Tuple i a`.
+type ValueWithIndex i a = { index :: i, value :: a }
+
 -- | Try to find an element in a data structure which satisfies a predicate
 -- | with access to the index.
 findWithIndex
@@ -266,8 +270,9 @@ findWithIndex
    . FoldableWithIndex i f
   => (i -> a -> Boolean)
   -> f a
-  -> Maybe a
+  -> Maybe (ValueWithIndex i a)
 findWithIndex p = foldlWithIndex go Nothing
   where
-  go i Nothing x | p i x = Just x
-  go i r _ = r
+  go :: i -> Maybe (ValueWithIndex i a) -> a -> Maybe (ValueWithIndex i a)
+  go i Nothing x | p i x = Just { index: i, value: x}
+  go _ r _ = r

--- a/src/Data/FoldableWithIndex.purs
+++ b/src/Data/FoldableWithIndex.purs
@@ -266,13 +266,13 @@ findWithIndex
    . FoldableWithIndex i f
   => (i -> a -> Boolean)
   -> f a
-  -> Maybe { index :: i, value :: a}
+  -> Maybe { index :: i, value :: a }
 findWithIndex p = foldlWithIndex go Nothing
   where
   go
     :: i
-    -> Maybe { index :: i, value :: a}
+    -> Maybe { index :: i, value :: a }
     -> a
-    -> Maybe { index :: i, value :: a}
-  go i Nothing x | p i x = Just { index: i, value: x}
+    -> Maybe { index :: i, value :: a }
+  go i Nothing x | p i x = Just { index: i, value: x }
   go _ r _ = r

--- a/test/Main.purs
+++ b/test/Main.purs
@@ -100,7 +100,10 @@ main = do
   assert $ find (\x -> x `mod` 2 == 0) [1, 4, 10] == Just 4
 
   log "Test findWithIndex"
-  assert $ findWithIndex (\i x -> i == 2 && x `mod` 2 == 0) [1, 2, 4, 6] == Just 4
+  assert $
+    case findWithIndex (\i x -> i `mod` 2 == 0 && x `mod` 2 == 0) [1, 2, 4, 6] of
+      Nothing -> false
+      Just { index, value } -> index == 2 && value == 4
 
   log "Test findMap" *> do
     let pred x = if x > 5 then Just (x * 100) else Nothing


### PR DESCRIPTION
Yeah, I've screwed up slightly in the previous PR: haskell's `findWithIndex` also returns the index of the found value, and I forgot to do it here. This should fix it.

Because Data.Tuple depends on this package, `findWithIndex` can't return
an actual `Tuple`. `ValueWithIndex` exists as a workaround.

Also tweaks the test slightly, and adds a type signature for a local
function.