### PR TITLE
Fix test for foldrDefault

### DIFF
--- a/test/Main.purs
+++ b/test/Main.purs
@@ -42,7 +42,7 @@ main = do
   testFoldableFoldlDefault 20
 
   log "Test foldrDefault"
-  testFoldableFoldlDefault 20
+  testFoldableFoldrDefault 20
 
   log "Test traversableArray instance"
   testTraversableArrayWith 20


### PR DESCRIPTION
* Fix test for foldrDefault

The test labelled "Test foldrDefault" was calling the function to test
fold*l*Default (`testFoldableFoldlDefault`). The test for
foldrDefault (`testFoldableFoldrDefault`) was never called.