### PR TITLE
default non-indexed impls using indexed impls

### DIFF
--- a/src/Data/FoldableWithIndex.purs
+++ b/src/Data/FoldableWithIndex.purs
@@ -11,6 +11,9 @@ module Data.FoldableWithIndex
   , allWithIndex
   , anyWithIndex
   , findWithIndex
+  , foldrDefault
+  , foldlDefault
+  , foldMapDefault
   ) where
 
 import Prelude
@@ -271,3 +274,25 @@ findWithIndex p = foldlWithIndex go Nothing
   where
   go i Nothing x | p i x = Just x
   go i r _ = r
+
+-- | A default implementation of `foldr` using `foldrWithIndex`
+foldrDefault
+  :: forall i f a b
+   . FoldableWithIndex i f
+  => (a -> b -> b) -> b -> f a -> b
+foldrDefault f = foldrWithIndex (const f)
+
+-- | A default implementation of `foldl` using `foldlWithIndex`
+foldlDefault
+  :: forall i f a b
+   . FoldableWithIndex i f
+  => (b -> a -> b) -> b -> f a -> b
+foldlDefault f = foldlWithIndex (const f)
+
+-- | A default implementation of `foldMap` using `foldMapWithIndex`
+foldMapDefault
+  :: forall i f a m
+   . FoldableWithIndex i f
+  => Monoid m
+  => (a -> m) -> f a -> m
+foldMapDefault f = foldMapWithIndex (const f)

--- a/src/Data/FunctorWithIndex.purs
+++ b/src/Data/FunctorWithIndex.purs
@@ -1,5 +1,5 @@
 module Data.FunctorWithIndex
-  ( class FunctorWithIndex, mapWithIndex
+  ( class FunctorWithIndex, mapWithIndex, mapDefault
   ) where
 
 import Prelude
@@ -55,3 +55,7 @@ instance functorWithIndexDisj :: FunctorWithIndex Unit Disj where
 
 instance functorWithIndexMultiplicative :: FunctorWithIndex Unit Multiplicative where
   mapWithIndex f = map $ f unit
+
+-- | A default implementation of Functor's `map` in terms of `mapWithIndex`
+mapDefault :: forall i f a b. FunctorWithIndex i f => (a -> b) -> f a -> f b
+mapDefault f = mapWithIndex (const f)

--- a/src/Data/TraversableWithIndex.purs
+++ b/src/Data/TraversableWithIndex.purs
@@ -6,6 +6,7 @@ module Data.TraversableWithIndex
   , mapAccumLWithIndex
   , scanrWithIndex
   , mapAccumRWithIndex
+  , traverseDefault
   , module Data.Traversable.Accum
   ) where
 
@@ -166,3 +167,11 @@ mapAccumRWithIndex
   -> f a
   -> Accum s (f b)
 mapAccumRWithIndex f s0 xs = stateR (traverseWithIndex (\i a -> StateR \s -> f i s a) xs) s0
+
+-- | A default implementation of `traverse` in terms of `traverseWithIndex`
+traverseDefault
+  :: forall i t a b m
+   . TraversableWithIndex i t
+  => Applicative m
+  => (a -> m b) -> t a -> m (t b)
+traverseDefault f = traverseWithIndex (const f)


### PR DESCRIPTION
A series of functions allowing one to define instances for the non-indexed versions of `Functor`, `Foldable`, and `Traversable` in terms of their indexed counterparts.

Addresses https://github.com/purescript/purescript-foldable-traversable/issues/87