### PR TITLE
added traverseM

### DIFF
--- a/src/Data/Traversable.purs
+++ b/src/Data/Traversable.purs
@@ -1,6 +1,7 @@
 module Data.Traversable
   ( class Traversable, traverse, sequence
   , traverseDefault, sequenceDefault
+  , traverseM
   , for
   , scanl
   , scanr
@@ -69,6 +70,30 @@ sequenceDefault
   => t (m a)
   -> m (t a)
 sequenceDefault = traverse identity
+
+-- | A version of `traverse` where a `join` is applied to the inner result
+-- |
+-- | For example where `traverse` applied over an array of `Effect`s will produce `Effect (Array (Array _))` 
+-- | The same array applied to `traverseM` will results in `Effect (Array _)`
+-- |
+-- | testTraverseM :: Effect Unit
+-- | testTraverseM = do 
+-- |   result <- traverseM identity [ arrayZero, arrayOne, arrayTwo, arrayThree ] 
+-- |   assert $ result == [ 1, 2, 2, 3, 3, 3 ] 
+-- |   where
+-- |     arrayZero   = pure [ ]
+-- |     arrayOne    = pure [ 1 ]
+-- |     arrayTwo    = pure [ 2, 2 ]
+-- |     arrayThree  = pure [ 3, 3, 3 ]
+traverseM 
+  :: forall a b f t
+   . Applicative f
+  => Traversable t
+  => Bind t
+  => (a -> f (t b))
+  -> t a
+  -> f (t b)
+traverseM fn ta = join <$> traverse fn ta
 
 instance traversableArray :: Traversable Array where
   traverse = traverseArrayImpl apply map pure

--- a/test/Main.purs
+++ b/test/Main.purs
@@ -13,7 +13,7 @@ import Data.Int (toNumber, pow)
 import Data.Maybe (Maybe(..))
 import Data.Monoid.Additive (Additive(..))
 import Data.Newtype (unwrap)
-import Data.Traversable (class Traversable, sequenceDefault, traverse, sequence, traverseDefault)
+import Data.Traversable (class Traversable, sequenceDefault, traverse, traverseM, sequence, traverseDefault)
 import Data.TraversableWithIndex (class TraversableWithIndex, traverseWithIndex)
 import Effect (Effect, foreachE)
 import Effect.Console (log)
@@ -65,6 +65,9 @@ main = do
 
   log "Test sequenceDefault"
   testSequenceDefault 20
+
+  log "Test traverseM"
+  testTraverseM
 
   log "Test foldableWithIndexArray instance"
   testFoldableWithIndexArrayWith 20
@@ -384,6 +387,17 @@ testTraverseDefault = testTraversableFWith (TD <<< arrayFrom1UpTo)
 
 testSequenceDefault :: Int -> Effect Unit
 testSequenceDefault = testTraversableFWith (SD <<< arrayFrom1UpTo)
+
+
+testTraverseM :: Effect Unit
+testTraverseM = do 
+  result <- traverseM identity [ arrayZero, arrayOne, arrayTwo, arrayThree ] 
+  assert $ result == [ 1, 2, 2, 3, 3, 3 ] 
+  where
+    arrayZero   = pure [ ]
+    arrayOne    = pure [ 1 ]
+    arrayTwo    = pure [ 2, 2 ]
+    arrayThree  = pure [ 3, 3, 3 ]
 
 
 -- structure for testing bifoldable, picked `inclusive or` as it has both products and sums


### PR DESCRIPTION
I find myself using the following so often, that I assumed the function should already exist, but it doesn't: 
`join <$> traverse fn traversable` 

I've inquired on slack about it, I have see someone else inquire about it (i-am-the-slime), and someone else inquired on reddit: https://www.reddit.com/r/purescript/comments/aq31gu/i_feel_like_this_is_probably_a_standard_function/

@puffnfresh showed us that it exists in Scalaz: https://github.com/scalaz/scalaz/blob/series/7.3.x/core/src/main/scala/scalaz/Traverse.scala#L68

So I decided to make this PR to add it to `Data.Traversable`