### PR TITLE
Change foldM type signature to more closely match foldl

### DIFF
--- a/src/Data/Foldable.purs
+++ b/src/Data/Foldable.purs
@@ -177,8 +177,8 @@ fold = foldMap identity
 -- |
 -- | Note: this function is not generally stack-safe, e.g., for monads which
 -- | build up thunks a la `Eff`.
-foldM :: forall f m a b. Foldable f => Monad m => (a -> b -> m a) -> a -> f b -> m a
-foldM f a0 = foldl (\ma b -> ma >>= flip f b) (pure a0)
+foldM :: forall f m a b. Foldable f => Monad m => (b -> a -> m b) -> b -> f a -> m b
+foldM f b0 = foldl (\b a -> b >>= flip f a) (pure b0)
 
 -- | Traverse a data structure, performing some effects encoded by an
 -- | `Applicative` functor at each value, ignoring the final result.


### PR DESCRIPTION
This is a cosmetic change to follow the naming convention of other fold operations, and make the relationship to `foldl` more obvious.

Previously:
``` hs
foldl :: forall     a b.                          (b -> a ->   b) -> b -> f a ->   b
foldM :: forall f m a b. Foldable f => Monad m => (a -> b -> m a) -> a -> f b -> m a
```

With change:
``` hs
foldl :: forall     a b.                          (b -> a ->   b) -> b -> f a ->   b
foldM :: forall f m a b. Foldable f => Monad m => (b -> a -> m b) -> b -> f a -> m b
```

This also more closely [matches haskell](http://hackage.haskell.org/package/foldl-1.4.5/docs/Control-Foldl.html#v:foldM):
``` hs
foldM :: (Foldable f, Monad m) => FoldM m a b -> f a -> m b 
```
