### PR TITLE
Add maximumBy and minimumBy to Data.Semigroup.Foldable

### DIFF
--- a/src/Data/Semigroup/Foldable.purs
+++ b/src/Data/Semigroup/Foldable.purs
@@ -16,7 +16,9 @@ module Data.Semigroup.Foldable
   , intercalate
   , intercalateMap
   , maximum
+  , maximumBy
   , minimum
+  , minimumBy
   ) where
 
 import Prelude
@@ -118,8 +120,14 @@ sequence1_ = traverse1_ identity
 maximum :: forall f a. Ord a => Foldable1 f => f a -> a
 maximum = ala Max foldMap1
 
+maximumBy :: forall f a. Ord a => Foldable1 f => (a -> a -> Ordering) -> f a -> a
+maximumBy cmp = foldl1 \x y -> if cmp x y == GT then x else y
+
 minimum :: forall f a. Ord a => Foldable1 f => f a -> a
 minimum = ala Min foldMap1
+
+minimumBy :: forall f a. Ord a => Foldable1 f => (a -> a -> Ordering) -> f a -> a
+minimumBy cmp = foldl1 \x y -> if cmp x y == LT then x else y
 
 -- | Internal. Used by intercalation functions.
 newtype JoinWith a = JoinWith (a -> a)

--- a/src/Data/Semigroup/Foldable.purs
+++ b/src/Data/Semigroup/Foldable.purs
@@ -120,13 +120,13 @@ sequence1_ = traverse1_ identity
 maximum :: forall f a. Ord a => Foldable1 f => f a -> a
 maximum = ala Max foldMap1
 
-maximumBy :: forall f a. Ord a => Foldable1 f => (a -> a -> Ordering) -> f a -> a
+maximumBy :: forall f a. Foldable1 f => (a -> a -> Ordering) -> f a -> a
 maximumBy cmp = foldl1 \x y -> if cmp x y == GT then x else y
 
 minimum :: forall f a. Ord a => Foldable1 f => f a -> a
 minimum = ala Min foldMap1
 
-minimumBy :: forall f a. Ord a => Foldable1 f => (a -> a -> Ordering) -> f a -> a
+minimumBy :: forall f a. Foldable1 f => (a -> a -> Ordering) -> f a -> a
 minimumBy cmp = foldl1 \x y -> if cmp x y == LT then x else y
 
 -- | Internal. Used by intercalation functions.

--- a/test/Main.purs
+++ b/test/Main.purs
@@ -14,6 +14,7 @@ import Data.Maybe (Maybe(..))
 import Data.Monoid.Additive (Additive(..))
 import Data.Newtype (unwrap)
 import Data.Semigroup.Foldable (class Foldable1, foldr1, foldl1, fold1Default, foldr1Default, foldl1Default)
+import Data.Semigroup.Foldable as Foldable1
 import Data.Traversable (class Traversable, sequenceDefault, traverse, sequence, traverseDefault)
 import Data.TraversableWithIndex (class TraversableWithIndex, traverseWithIndex)
 import Effect (Effect, foreachE)
@@ -199,6 +200,18 @@ main = do
   log "Test Foldable1 defaults"
   assert $ "(a(b(cd)))" == foldMap (foldr1 (\x y -> "(" <> x <> y <> ")")) (maybeMkNEArray ["a", "b", "c", "d"])
   assert $ "(((ab)c)d)" == foldMap (foldl1 (\x y -> "(" <> x <> y <> ")")) (maybeMkNEArray ["a", "b", "c", "d"])
+
+  log "Test maximumBy"
+  assert $
+    (Foldable1.maximumBy (compare `on` abs) <$>
+        (maybeMkNEArray (negate <<< toNumber <$> arrayFrom1UpTo 10)))
+      == Just (-10.0)
+
+  log "Test minimumBy"
+  assert $
+    (Foldable1.minimumBy (compare `on` abs) <$>
+        (maybeMkNEArray (negate <<< toNumber <$> arrayFrom1UpTo 10)))
+      == Just (-1.0)
 
   log "All done!"
 


### PR DESCRIPTION
This became possible with https://github.com/purescript/purescript-foldable-traversable/pull/121.