### PR TITLE
Remove fold1 from Foldable1

### DIFF
--- a/test/Main.purs
+++ b/test/Main.purs
@@ -13,7 +13,7 @@ import Data.Int (toNumber, pow)
 import Data.Maybe (Maybe(..))
 import Data.Monoid.Additive (Additive(..))
 import Data.Newtype (unwrap)
-import Data.Semigroup.Foldable (class Foldable1, foldr1, foldl1, fold1Default, foldr1Default, foldl1Default)
+import Data.Semigroup.Foldable (class Foldable1, foldr1, foldl1, foldr1Default, foldl1Default)
 import Data.Semigroup.Foldable as Foldable1
 import Data.Traversable (class Traversable, sequenceDefault, traverse, sequence, traverseDefault)
 import Data.TraversableWithIndex (class TraversableWithIndex, traverseWithIndex)
@@ -36,10 +36,9 @@ instance foldableNEArray :: Foldable NEArray where
   foldr f = foldrDefault f
 
 instance foldable1NEArray :: Foldable1 NEArray where
-  foldMap1 = foldMap1NEArray append
-  fold1 = fold1Default
   foldr1 f = foldr1Default f
   foldl1 f = foldl1Default f
+  foldMap1 = foldMap1NEArray append
 
 maybeMkNEArray :: forall a. Array a -> Maybe (NEArray a)
 maybeMkNEArray = mkNEArray Nothing Just


### PR DESCRIPTION
Neither Foldable nor Bifoldable have a fold or a bifold method, is there any reason for Foldable1 to have fold1?

The only use of foldMap1Default in core libraries occurs in the Foldable1 instance for NonEmptyArray but this is easy enough to fix with a JavaScript implementation (like we do for foldr1 and foldl1), which should also be more efficient since it wouldn’t have to iterate through the array twice.

Close https://github.com/purescript/purescript-foldable-traversable/issues/125, close https://github.com/purescript/purescript-foldable-traversable/issues/117.