### PR TITLE
Refactor functors and related packages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ Other improvements:
 - Wrapped `traverseArrayImpl` IIFE in parentheses (#52)
 - Added examples for `sequence` and `traverse` (#115)
 - Changed `foldM` type signature to more closely match `foldl` (#111)
+- This package now depends on the `purescript-const`, `purescript-either`, `purescript-functors`, `purescript-identity`, and `purescript-tuples` packages, and contains instances previously in those packages or the `purescript-bifunctors` or `purescript-profunctor` packages (#131)
 
 ## [v4.1.1](https://github.com/purescript/purescript-foldable-traversable/releases/tag/v4.1.1) - 2018-11-23
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ New features:
 - Added `findMapWithIndex` (#119)
 - Added `foldr1`, `foldl1`, `foldr1Default`, `foldl1Default`, `foldMap1DefaultR`, `foldMap1DefaultL` (#121, #128)
 - Added `maximumBy` and `minimumBy` to `Data.Semigroup.Foldable` (#123) 
+- Added `lookup` to `Data.Foldable`; this function previously lived in `Data.Tuple` in the `purescript-tuples` package (#131)
 
 Bugfixes:
 

--- a/bower.json
+++ b/bower.json
@@ -18,11 +18,16 @@
   ],
   "dependencies": {
     "purescript-bifunctors": "master",
+    "purescript-const": "master",
     "purescript-control": "master",
+    "purescript-either": "master",
+    "purescript-functors": "master",
+    "purescript-identity": "master",
     "purescript-maybe": "master",
     "purescript-newtype": "master",
     "purescript-orders": "master",
-    "purescript-prelude": "master"
+    "purescript-prelude": "master",
+    "purescript-tuples": "master"
   },
   "devDependencies": {
     "purescript-assert": "master",

--- a/src/Data/Bifoldable.purs
+++ b/src/Data/Bifoldable.purs
@@ -3,17 +3,19 @@ module Data.Bifoldable where
 import Prelude
 
 import Control.Apply (applySecond)
+import Data.Const (Const(..))
+import Data.Either (Either(..))
+import Data.Foldable (class Foldable, foldr, foldl, foldMap)
+import Data.Functor.Clown (Clown(..))
+import Data.Functor.Flip (Flip(..))
+import Data.Functor.Joker (Joker(..))
+import Data.Functor.Product2 (Product2(..))
 import Data.Monoid.Conj (Conj(..))
 import Data.Monoid.Disj (Disj(..))
 import Data.Monoid.Dual (Dual(..))
 import Data.Monoid.Endo (Endo(..))
 import Data.Newtype (unwrap)
-import Data.Foldable (class Foldable, foldr, foldl, foldMap)
-import Data.Bifunctor.Clown (Clown(..))
-import Data.Bifunctor.Joker (Joker(..))
-import Data.Bifunctor.Flip (Flip(..))
-import Data.Bifunctor.Product (Product(..))
-import Data.Bifunctor.Wrap (Wrap(..))
+import Data.Tuple (Tuple(..))
 
 -- | `Bifoldable` represents data structures with two type arguments which can be
 -- | folded.
@@ -52,15 +54,28 @@ instance bifoldableFlip :: Bifoldable p => Bifoldable (Flip p) where
   bifoldl r l u (Flip p) = bifoldl l r u p
   bifoldMap r l (Flip p) = bifoldMap l r p
 
-instance bifoldableProduct :: (Bifoldable f, Bifoldable g) => Bifoldable (Product f g) where
+instance bifoldableProduct2 :: (Bifoldable f, Bifoldable g) => Bifoldable (Product2 f g) where
   bifoldr l r u m = bifoldrDefault l r u m
   bifoldl l r u m = bifoldlDefault l r u m
-  bifoldMap l r (Product f g) = bifoldMap l r f <> bifoldMap l r g
+  bifoldMap l r (Product2 f g) = bifoldMap l r f <> bifoldMap l r g
 
-instance bifoldableWrap :: Bifoldable p => Bifoldable (Wrap p) where
-  bifoldr l r u (Wrap p) = bifoldr l r u p
-  bifoldl l r u (Wrap p) = bifoldl l r u p
-  bifoldMap l r (Wrap p) = bifoldMap l r p
+instance bifoldableEither :: Bifoldable Either where
+  bifoldr f _ z (Left a) = f a z
+  bifoldr _ g z (Right b) = g b z
+  bifoldl f _ z (Left a) = f z a
+  bifoldl _ g z (Right b) = g z b
+  bifoldMap f _ (Left a) = f a
+  bifoldMap _ g (Right b) = g b
+
+instance bifoldableTuple :: Bifoldable Tuple where
+  bifoldMap f g (Tuple a b) = f a <> g b
+  bifoldr f g z (Tuple a b) = f a (g b z)
+  bifoldl f g z (Tuple a b) = g (f z a) b
+
+instance bifoldableConst :: Bifoldable Const where
+  bifoldr f _ z (Const a) = f a z
+  bifoldl f _ z (Const a) = f z a
+  bifoldMap f _ (Const a) = f a
 
 -- | A default implementation of `bifoldr` using `bifoldMap`.
 -- |

--- a/src/Data/Bitraversable.purs
+++ b/src/Data/Bitraversable.purs
@@ -15,11 +15,13 @@ import Prelude
 import Data.Bifoldable (class Bifoldable, biall, biany, bifold, bifoldMap, bifoldMapDefaultL, bifoldMapDefaultR, bifoldl, bifoldlDefault, bifoldr, bifoldrDefault, bifor_, bisequence_, bitraverse_)
 import Data.Traversable (class Traversable, traverse, sequence)
 import Data.Bifunctor (class Bifunctor, bimap)
-import Data.Bifunctor.Clown (Clown(..))
-import Data.Bifunctor.Joker (Joker(..))
-import Data.Bifunctor.Flip (Flip(..))
-import Data.Bifunctor.Product (Product(..))
-import Data.Bifunctor.Wrap (Wrap(..))
+import Data.Const (Const(..))
+import Data.Either (Either(..))
+import Data.Functor.Clown (Clown(..))
+import Data.Functor.Flip (Flip(..))
+import Data.Functor.Joker (Joker(..))
+import Data.Functor.Product2 (Product2(..))
+import Data.Tuple (Tuple(..))
 
 -- | `Bitraversable` represents data structures with two type arguments which can be
 -- | traversed.
@@ -48,13 +50,23 @@ instance bitraversableFlip :: Bitraversable p => Bitraversable (Flip p) where
   bitraverse r l (Flip p) = Flip <$> bitraverse l r p
   bisequence (Flip p) = Flip <$> bisequence p
 
-instance bitraversableProduct :: (Bitraversable f, Bitraversable g) => Bitraversable (Product f g) where
-  bitraverse l r (Product f g) = Product <$> bitraverse l r f <*> bitraverse l r g
-  bisequence (Product f g) = Product <$> bisequence f <*> bisequence g
+instance bitraversableProduct2 :: (Bitraversable f, Bitraversable g) => Bitraversable (Product2 f g) where
+  bitraverse l r (Product2 f g) = Product2 <$> bitraverse l r f <*> bitraverse l r g
+  bisequence (Product2 f g) = Product2 <$> bisequence f <*> bisequence g
 
-instance bitraversableWrap :: Bitraversable p => Bitraversable (Wrap p) where
-  bitraverse l r (Wrap p) = Wrap <$> bitraverse l r p
-  bisequence (Wrap p) = Wrap <$> bisequence p
+instance bitraversableEither :: Bitraversable Either where
+  bitraverse f _ (Left a) = Left <$> f a
+  bitraverse _ g (Right b) = Right <$> g b
+  bisequence (Left a) = Left <$> a
+  bisequence (Right b) = Right <$> b
+
+instance bitraversableTuple :: Bitraversable Tuple where
+  bitraverse f g (Tuple a b) = Tuple <$> f a <*> g b
+  bisequence (Tuple a b) = Tuple <$> a <*> b
+
+instance bitraversableConst :: Bitraversable Const where
+  bitraverse f _ (Const a) = Const <$> f a
+  bisequence (Const a) = Const <$> a
 
 ltraverse
   :: forall t b c a f

--- a/src/Data/Foldable.purs
+++ b/src/Data/Foldable.purs
@@ -34,6 +34,13 @@ module Data.Foldable
 import Prelude
 
 import Control.Plus (class Plus, alt, empty)
+import Data.Const (Const)
+import Data.Either (Either(..))
+import Data.Functor.App (App(..))
+import Data.Functor.Compose (Compose(..))
+import Data.Functor.Coproduct (Coproduct, coproduct)
+import Data.Functor.Product (Product(..))
+import Data.Identity (Identity(..))
 import Data.Maybe (Maybe(..))
 import Data.Maybe.First (First(..))
 import Data.Maybe.Last (Last(..))
@@ -44,6 +51,7 @@ import Data.Monoid.Dual (Dual(..))
 import Data.Monoid.Endo (Endo(..))
 import Data.Monoid.Multiplicative (Multiplicative(..))
 import Data.Newtype (alaF, unwrap)
+import Data.Tuple (Tuple(..))
 
 -- | `Foldable` represents data structures which can be _folded_.
 -- |
@@ -168,6 +176,49 @@ instance foldableMultiplicative :: Foldable Multiplicative where
   foldr f z (Multiplicative x) = x `f` z
   foldl f z (Multiplicative x) = z `f` x
   foldMap f (Multiplicative x) = f x
+
+instance foldableEither :: Foldable (Either a) where
+  foldr _ z (Left _)  = z
+  foldr f z (Right x) = f x z
+  foldl _ z (Left _)  = z
+  foldl f z (Right x) = f z x
+  foldMap f (Left _)  = mempty
+  foldMap f (Right x) = f x
+
+instance foldableTuple :: Foldable (Tuple a) where
+  foldr f z (Tuple _ x) = f x z
+  foldl f z (Tuple _ x) = f z x
+  foldMap f (Tuple _ x) = f x
+
+instance foldableIdentity :: Foldable Identity where
+  foldr f z (Identity x) = f x z
+  foldl f z (Identity x) = f z x
+  foldMap f (Identity x) = f x
+
+instance foldableConst :: Foldable (Const a) where
+  foldr _ z _ = z
+  foldl _ z _ = z
+  foldMap _ _ = mempty
+
+instance foldableProduct :: (Foldable f, Foldable g) => Foldable (Product f g) where
+  foldr f z (Product (Tuple fa ga)) = foldr f (foldr f z ga) fa
+  foldl f z (Product (Tuple fa ga)) = foldl f (foldl f z fa) ga
+  foldMap f (Product (Tuple fa ga)) = foldMap f fa <> foldMap f ga
+
+instance foldableCoproduct :: (Foldable f, Foldable g) => Foldable (Coproduct f g) where
+  foldr f z = coproduct (foldr f z) (foldr f z)
+  foldl f z = coproduct (foldl f z) (foldl f z)
+  foldMap f = coproduct (foldMap f) (foldMap f)
+
+instance foldableCompose :: (Foldable f, Foldable g) => Foldable (Compose f g) where
+  foldr f i (Compose fga) = foldr (flip (foldr f)) i fga
+  foldl f i (Compose fga) = foldl (foldl f) i fga
+  foldMap f (Compose fga) = foldMap (foldMap f) fga
+
+instance foldableApp :: Foldable f => Foldable (App f) where
+  foldr f i (App x) = foldr f i x
+  foldl f i (App x) = foldl f i x
+  foldMap f (App x) = foldMap f x
 
 -- | Fold a data structure, accumulating values in some `Monoid`.
 fold :: forall f m. Foldable f => Monoid m => f m -> m
@@ -413,3 +464,7 @@ null = foldr (\_ _ -> false) true
 -- | is no general way to do better.
 length :: forall a b f. Foldable f => Semiring b => f a -> b
 length = foldl (\c _ -> add one c) zero
+
+-- | Lookup a value in a data structure of `Tuple`s, generalizing association lists.
+lookup :: forall a b f. Foldable f => Eq a => a -> f (Tuple a b) -> Maybe b
+lookup a = unwrap <<< foldMap \(Tuple a' b) -> First (if a == a' then Just b else Nothing)

--- a/src/Data/Semigroup/Foldable.purs
+++ b/src/Data/Semigroup/Foldable.purs
@@ -23,11 +23,13 @@ module Data.Semigroup.Foldable
 import Prelude
 
 import Data.Foldable (class Foldable)
+import Data.Identity (Identity(..))
 import Data.Monoid.Dual (Dual(..))
 import Data.Monoid.Multiplicative (Multiplicative(..))
 import Data.Newtype (ala, alaF)
 import Data.Ord.Max (Max(..))
 import Data.Ord.Min (Min(..))
+import Data.Tuple (Tuple(..))
 import Prim.TypeError (class Warn, Text)
 
 -- | `Foldable1` represents data structures with a minimum of one element that can be _folded_.
@@ -92,6 +94,16 @@ instance foldableMultiplicative :: Foldable1 Multiplicative where
   foldr1 _ (Multiplicative x) = x
   foldl1 _ (Multiplicative x) = x
   foldMap1 f (Multiplicative x) = f x
+
+instance foldable1Tuple :: Foldable1 (Tuple a) where
+  foldMap1 f (Tuple _ x) = f x
+  foldr1 _ (Tuple _ x) = x
+  foldl1 _ (Tuple _ x) = x
+
+instance foldableIdentity :: Foldable1 Identity where
+  foldMap1 f (Identity x) = f x
+  foldl1 _ (Identity x) = x
+  foldr1 _ (Identity x) = x
 
 -- | Fold a data structure, accumulating values in some `Semigroup`.
 fold1 :: forall t m. Foldable1 t => Semigroup m => t m -> m

--- a/src/Data/Semigroup/Foldable.purs
+++ b/src/Data/Semigroup/Foldable.purs
@@ -95,7 +95,7 @@ instance foldableMultiplicative :: Foldable1 Multiplicative where
   foldl1 _ (Multiplicative x) = x
   foldMap1 f (Multiplicative x) = f x
 
-instance foldable1Tuple :: Foldable1 (Tuple a) where
+instance foldableTuple :: Foldable1 (Tuple a) where
   foldMap1 f (Tuple _ x) = f x
   foldr1 _ (Tuple _ x) = x
   foldl1 _ (Tuple _ x) = x

--- a/src/Data/Semigroup/Traversable.purs
+++ b/src/Data/Semigroup/Traversable.purs
@@ -2,10 +2,12 @@ module Data.Semigroup.Traversable where
 
 import Prelude
 
+import Data.Identity (Identity(..))
 import Data.Monoid.Dual (Dual(..))
 import Data.Monoid.Multiplicative (Multiplicative(..))
 import Data.Semigroup.Foldable (class Foldable1)
 import Data.Traversable (class Traversable)
+import Data.Tuple (Tuple(..))
 
 -- | `Traversable1` represents data structures with a minimum of one element that can be _traversed_,
 -- | accumulating results and effects in some `Applicative` functor.
@@ -41,6 +43,14 @@ instance traversableDual :: Traversable1 Dual where
 instance traversableMultiplicative :: Traversable1 Multiplicative where
   traverse1 f (Multiplicative x) = Multiplicative <$> f x
   sequence1 = sequence1Default
+
+instance traversableTuple :: Traversable1 (Tuple a) where
+  traverse1 f (Tuple x y) = Tuple x <$> f y
+  sequence1 (Tuple x y) = Tuple x <$> y
+
+instance traversableIdentity :: Traversable1 Identity where
+  traverse1 f (Identity x) = Identity <$> f x
+  sequence1 (Identity x) = Identity <$> x
 
 -- | A default implementation of `traverse1` using `sequence1`.
 traverse1Default


### PR DESCRIPTION
This is part of a set of commits that rearrange the dependencies between
multiple packages. The immediate motivation is to allow certain newtypes
to be reused between `profunctor` and `bifunctors`, but this particular
approach goes a little beyond that in two ways: first, it attempts to
move data types (`either`, `tuple`) toward the bottom of the dependency
stack; and second, it tries to ensure no package comes between
`functors` and the packages most closely related to it, in order to open
the possibility of merging those packages together (which may be
desirable if at some point in the future additional newtypes are added
which reveal new and exciting constraints on the module dependency
graph).

**Description of the change**

See discussion in purescript/purescript-profunctor#23.

---

**Checklist:**

- [x] Added the change to the changelog's "Unreleased" section with a reference to this PR (e.g. "- Made a change (#0000)")
- [ ] Linked any existing issues or proposals that this pull request should close
- [ ] Updated or added relevant documentation
- [ ] Added a test for the contribution (if applicable)
