### PR TITLE
Change types in traverseArrayImpl to be more truthful

### DIFF
--- a/src/Data/Traversable.purs
+++ b/src/Data/Traversable.purs
@@ -105,9 +105,9 @@ instance traversableArray :: Traversable Array where
 
 foreign import traverseArrayImpl
   :: forall m a b
-   . (m (a -> b) -> m a -> m b)
-  -> ((a -> b) -> m a -> m b)
-  -> (a -> m a)
+   . (forall x y. m (x -> y) -> m x -> m y)
+  -> (forall x y. (x -> y) -> m x -> m y)
+  -> (forall x. x -> m x)
   -> (a -> m b)
   -> Array a
   -> m (Array b)


### PR DESCRIPTION
**Description of the change**

This PR changes the types of `traverseArrayImpl` to be more true to how they are actually used.

This changes `traverseArrayImpl` from

```purescript
traverseArrayImpl
  :: forall m a b
   . (m (a -> b) -> m a -> m b)
  -> ((a -> b) -> m a -> m b)
  -> (a -> m a)
  -> (a -> m b)
  -> Array a
  -> m (Array b)
```

to

```purescript
traverseArrayImpl
  :: forall m a b
   . (forall x y. m (x -> y) -> m x -> m y)
  -> (forall x y. (x -> y) -> m x -> m y)
  -> (forall x. x -> m x)
  -> (a -> m b)
  -> Array a
  -> m (Array b)
```

`traverseArrayImpl` is called like the following:

```purescript
instance traversableArray :: Traversable Array where
   traverse = traverseArrayImpl apply map pure  
```

Here the `apply`, `map`, and `pure` functions are all polymorphic in their arguments (the `x` and `y` in the changed type above), so this new type for `traverseArrayImpl` is more true.

Also, in the FFI files for `traverseArrayImpl`, `apply`, `map`, and `pure` are used as if they are polymorphic.  For instance, `pure` is used on an `Array`, not an `a`:

https://github.com/purescript/purescript-foldable-traversable/blob/d581caf260772b1b446c11ac3c8be807b290b220/src/Data/Traversable.js#L37

---

**Checklist:**

- [ ] Added the change to the changelog's "Unreleased" section with a reference to this PR (e.g. "- Made a change (#0000)")
- [x] Linked any existing issues or proposals that this pull request should close
- [x] Updated or added relevant documentation
- [x] Added a test for the contribution (if applicable)
