### PR TITLE
Narrow down unnecessarily imprecise type

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ New features:
 Bugfixes:
 
 Other improvements:
+- Narrow down unnecessarily imprecise type of `mapWithIndexArray` (#145)
 
 ## [v5.0.1](https://github.com/purescript/purescript-foldable-traversable/releases/tag/v5.0.1) - 2021-04-20
 

--- a/src/Data/FunctorWithIndex.purs
+++ b/src/Data/FunctorWithIndex.purs
@@ -35,7 +35,7 @@ import Data.Tuple (Tuple, curry)
 class Functor f <= FunctorWithIndex i f | f -> i where
   mapWithIndex :: forall a b. (i -> a -> b) -> f a -> f b
 
-foreign import mapWithIndexArray :: forall i a b. (i -> a -> b) -> Array a -> Array b
+foreign import mapWithIndexArray :: forall a b. (Int -> a -> b) -> Array a -> Array b
 
 instance functorWithIndexArray :: FunctorWithIndex Int Array where
   mapWithIndex = mapWithIndexArray


### PR DESCRIPTION
**Description of the change**

Narrow down type of `mapWithIndexArray`, which is unnecessarily broad. Fixes #143.

---

**Checklist:**

- [x] Added the change to the changelog's "Unreleased" section with a reference to this PR (e.g. "- Made a change (#0000)")
- [x] Linked any existing issues or proposals that this pull request should close
- [ ] Updated or added relevant documentation
- [ ] Added a test for the contribution (if applicable)
